### PR TITLE
limit Qt widget updates to 4Hz when doing final rendering

### DIFF
--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -1682,8 +1682,8 @@ void DisplayWidget::renderTile ( double pad, double time, int subframes, int w, 
 
         if ( !progress->wasCanceled() ) {
 
-            // 4Hz display update frequency should be enough for humans
-            if ( refresh.elapsed() > 1000/4 ) {
+            // 30Hz display update frequency should be enough for humans
+            if ( refresh.elapsed() > 1000/30 ) {
                 refresh.restart();
                 progress->setValue ( *steps );
                 progress->setLabelText ( tr( "Tile:%1.%2\nof %3\nSize:%4\n avg sec/tile:%5 ETA:%6" )

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -1631,7 +1631,7 @@ void DisplayWidget::getRGBAFtile ( Array2D<Rgba>&array, int w, int h ) {
 }
 #endif
 
-void DisplayWidget::renderTile ( double pad, double time, int subframes, int w, int h, int tile, int tileMax, QProgressDialog* progress, int *steps, QImage *im ) {
+void DisplayWidget::renderTile ( double pad, double time, int subframes, int w, int h, int tile, int tileMax, QProgressDialog* progress, int *steps, QImage *im, QTime &refresh ) {
     tiles = tileMax;
     tilesCount = tile;
     padding = pad;
@@ -1682,16 +1682,20 @@ void DisplayWidget::renderTile ( double pad, double time, int subframes, int w, 
 
         if ( !progress->wasCanceled() ) {
 
-            progress->setValue ( *steps );
-            progress->setLabelText ( tr( "Tile:%1.%2\nof %3\nSize:%4\n avg sec/tile:%5 ETA:%6" )
-                                    .arg ( tile,tileField,10, QChar ( '0' ) )
-                                    .arg ( i,subField,10,QChar ( '0' ) )
-                                    .arg ( frametile )
-                                    .arg ( framesize ) 
-                                    .arg ( (tileAVG/(tile+1))/1000.0 )
-                                    .arg ( renderETA ) );
+            // 4Hz display update frequency should be enough for humans
+            if ( refresh.elapsed() > 1000/4 ) {
+                refresh.restart();
+                progress->setValue ( *steps );
+                progress->setLabelText ( tr( "Tile:%1.%2\nof %3\nSize:%4\n avg sec/tile:%5 ETA:%6" )
+                                        .arg ( tile,tileField,10, QChar ( '0' ) )
+                                        .arg ( i,subField,10,QChar ( '0' ) )
+                                        .arg ( frametile )
+                                        .arg ( framesize )
+                                        .arg ( (tileAVG/(tile+1))/1000.0 )
+                                        .arg ( renderETA ) );
 
-            mainWindow->processGuiEvents();
+                mainWindow->processGuiEvents();
+            }
             
             ( *steps ) ++;
 

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
@@ -102,7 +102,7 @@ namespace Fragmentarium {
       ~DisplayWidget();
       
       void clearTileBuffer();
-      void renderTile(double pad, double time, int subframes, int w, int h, int tile, int tileMax, QProgressDialog* progress, int* steps, QImage *im);
+      void renderTile(double pad, double time, int subframes, int w, int h, int tile, int tileMax, QProgressDialog* progress, int* steps, QImage *im, QTime &refresh);
       
       /// Use this whenever a redraw is required.
       /// Calling this function multiple times will still only result in one redraw

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
@@ -1374,6 +1374,8 @@ retry:
 
             Array2D<Rgba> pixels (tileHeight, tileWidth);
 
+            QTime refresh;
+            refresh.start();
             for (int tile = 0; tile<maxTiles*maxTiles; tile++) {
 
               QTime tiletime;
@@ -1382,7 +1384,7 @@ retry:
               if (!progress.wasCanceled()) {
 
                     QImage im(tileWidth,tileHeight,QImage::Format_ARGB32); im.fill(Qt::black);
-                    engine->renderTile(padding,time, maxSubframes, tileWidth,tileHeight, tile, maxTiles, &progress, &steps, &im);
+                    engine->renderTile(padding,time, maxSubframes, tileWidth,tileHeight, tile, maxTiles, &progress, &steps, &im, refresh);
 
                     if (padding>0.0)  {
                         int w = im.width();
@@ -1445,6 +1447,8 @@ retry:
 #endif
         {
             
+            QTime refresh;
+            refresh.start();
             for (int tile = 0; tile<maxTiles*maxTiles; tile++) {
 
                 QTime tiletime;
@@ -1452,7 +1456,7 @@ retry:
                 
                 if (!progress.wasCanceled()) {
                     QImage im(tileWidth,tileHeight,QImage::Format_ARGB32); im.fill(Qt::black);
-                    engine->renderTile(padding,time, maxSubframes, tileWidth,tileHeight, tile, maxTiles, &progress, &steps, &im);
+                    engine->renderTile(padding,time, maxSubframes, tileWidth,tileHeight, tile, maxTiles, &progress, &steps, &im, refresh);
                     if (padding>0.0)  {
                         int nw = (int)(tileWidth / (1.0 + padding));
                         int nh = (int)(tileHeight / (1.0 + padding));


### PR DESCRIPTION
This does make the FragM GUI a little bit less responsive (eg some visible trails when dragging windows on top of FragM), but should reduce CPU load, increase rendering efficiency, and make it actually possible to read the numbers more easily.