### PR TITLE
better ETA reporting (minimal-change version)

### DIFF
--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -1631,7 +1631,7 @@ void DisplayWidget::getRGBAFtile ( Array2D<Rgba>&array, int w, int h ) {
 }
 #endif
 
-void DisplayWidget::renderTile ( double pad, double time, int subframes, int w, int h, int tile, int tileMax, QProgressDialog* progress, int *steps, QImage *im ) {
+void DisplayWidget::renderTile ( double pad, double time, int subframes, int w, int h, int tile, int tileMax, QProgressDialog* progress, int *steps, QImage *im, const QTime &totalTime ) {
     tiles = tileMax;
     tilesCount = tile;
     padding = pad;
@@ -1681,6 +1681,24 @@ void DisplayWidget::renderTile ( double pad, double time, int subframes, int w, 
 
 
         if ( !progress->wasCanceled() ) {
+
+            // compute ETA in ms
+            int64_t total = progress->maximum();
+            int64_t current = *steps;
+            int64_t elapsed = totalTime.elapsed();
+            int64_t eta = elapsed * (total - current) / (current + !current);
+
+            // format ETA to string
+            const int hour = 60 * 60 * 1000;
+            const int day = 24 * hour;
+            int days = eta / day;
+            eta %= day;
+            bool hours = eta >= hour;
+            QTime t(0,0,0,0);
+            t=t.addMSecs((int) eta);
+            if (days) renderETA = QString("%1:%2").arg(days).arg(t.toString("hh:mm:ss"));
+            else if (hours) renderETA = t.toString("hh:mm:ss");
+            else renderETA = t.toString("mm:ss");
 
             progress->setValue ( *steps );
             progress->setLabelText ( tr( "Tile:%1.%2\nof %3\nSize:%4\n avg sec/tile:%5 ETA:%6" )

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
@@ -102,7 +102,7 @@ namespace Fragmentarium {
       ~DisplayWidget();
       
       void clearTileBuffer();
-      void renderTile(double pad, double time, int subframes, int w, int h, int tile, int tileMax, QProgressDialog* progress, int* steps, QImage *im);
+      void renderTile(double pad, double time, int subframes, int w, int h, int tile, int tileMax, QProgressDialog* progress, int* steps, QImage *im, const QTime &totalTime);
       
       /// Use this whenever a redraw is required.
       /// Calling this function multiple times will still only result in one redraw


### PR DESCRIPTION
- DisplayWidget::renderTile() has a new argument const QTime &totalTime
- MainWindow::tileBasedRender() starts the timer before the per-frame loop
- DisplayWidget::renderTile() computes the ETA and formats the string when
  checking that the progress dialog has not been cancelled
- the 3 other places where ETA was computed with duplicated code are deleted
  as they no longer needed, because it has already been updated by the inner
  code in DisplayWidget::renderTile()

there is a very small performance regression for very light frags:

    Ctrl-N                              640x360x1x1 9999   4.7%  slower
    Mandelbulb.frag                   1920x1080x2x2  100   0.64% faster
    Raymond/examples/Bubbles.frag(*)  1920x1080x1x1   16   1.2%  faster

(*)https://code.mathr.co.uk/raymond/blob/dfbaf3bc9d9ed2940a12afc1bdb2d6d2db097229:/examples/Bubbles.frag