### PR TITLE
remove redundant include (allows build on Ubuntu 16)

### DIFF
--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
@@ -38,7 +38,6 @@
 #include <QOpenGLFunctions_ES2>
 
 #include <QOpenGLFunctions>
-#include <QOpenGLExtraFunctions>
 #include <QOpenGLVersionFunctions>
 
 #include <QOpenGLFramebufferObject>


### PR DESCRIPTION
This small change allows building on Ubuntu 16.04 Xenial with Qt 5.5.  I checked in a Debian Buster chroot with Qt 5.11, still builds fine.