### PR TITLE
print a nicer message on segfault

### DIFF
--- a/Fragmentarium-Source/Fragmentarium/Main.cpp
+++ b/Fragmentarium-Source/Fragmentarium/Main.cpp
@@ -7,10 +7,30 @@
 
 #include "Fragmentarium/GUI/MainWindow.h"
 
-// Needed for unicode commandline below.
 #ifdef Q_OS_WIN
+
+// Needed for unicode commandline below.
 #define WIN32_LEAN_AND_MEAN
 #include "windows.h"
+
+#else
+
+// segfault signal handler prints a nicer message
+#include <signal.h>
+#include <unistd.h>
+void segv_handler(int s)
+{
+    // can't use most functions in a signal handler, see `man signal-safety`
+    const char *message =
+        "Segmentation fault.\n"
+        "Fragmentarium crashed!\n"
+        "For advice, please visit:\n"
+        "<https://en.wikibooks.org/wiki/Fractals/fragmentarium#Troubleshooting>\n"
+        ;
+    write(2 /* stderr FD */, message, strlen(message));
+    abort();
+}
+
 #endif
 
 int main(int argc, char *argv[])
@@ -21,6 +41,9 @@ int main(int argc, char *argv[])
     qApp->addLibraryPath("iconengines");
     qApp->addLibraryPath("imageformats");
     qApp->addLibraryPath("platforms");
+#else
+    // install signal handler to catch segmentation fault
+    signal(SIGSEGV, segv_handler);
 #endif
 
 


### PR DESCRIPTION
Error message with URL to `stderr`, tested and works on Linux.  Confirmed it doesn't interfere with debugging in `gdb`.

English only for now, translation functionality is almost certainly not safe to call in a signal handler.  Might be possible to set a global pointer with the translated string during startup?

May need to wait to merge until fractals wikibooks editors approve the changes for the embedded URL to be public (without being logged in there), otherwise it could lead nowhere.

A different approach is needed on Windows, it has its own error handling stuff.