### PR TITLE
[feature] support OpenGL 3

### DIFF
--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -404,7 +404,9 @@ void DisplayWidget::setGlTexParameter(QMap<QString, QString> map)
 // this function parses the assembler text and returns a string list containing the lines
 QStringList DisplayWidget::shaderAsm(bool w)
 {
-
+#ifndef USE_OPENGL_4
+                return QStringList("This build is compiled without support for OpenGL 4!");
+#else
     if (!foundnV) {
         if( context()->format().majorVersion() < 4 &&
                 context()->format().profile() != QSurfaceFormat::CompatibilityProfile) {
@@ -501,6 +503,7 @@ QStringList DisplayWidget::shaderAsm(bool w)
 //     }
 
     return asmList;
+#endif
 }
 
 void DisplayWidget::initFragmentShader()
@@ -1363,6 +1366,7 @@ void DisplayWidget::setFloatType(GLenum type, QString &tp)
         }
 }
 
+#ifdef USE_OPENGL_4
 void DisplayWidget::setDoubleType(GLuint programID, GLenum type, QString uniformName, QString uniformValue, bool &foundDouble, QString &tp)
 {
     double x,y,z,w;
@@ -1430,6 +1434,7 @@ void DisplayWidget::setDoubleType(GLuint programID, GLenum type, QString uniform
         }
     }
 }
+#endif
 
 void DisplayWidget::setShaderUniforms(QOpenGLShaderProgram *shaderProg)
 {
@@ -1492,7 +1497,11 @@ void DisplayWidget::setShaderUniforms(QOpenGLShaderProgram *shaderProg)
         if (context()->format().majorVersion() > 2 && context()->format().minorVersion() >= 0) {
             // do not try to set special, gl_ or unused uniform even if it is double type
             if (!uniformValue.contains("variable")) {
+#ifdef USE_OPENGL_4
                 setDoubleType(programID, type, uniformName, uniformValue, foundDouble, tp);
+#else
+                setFloatType(type, tp);
+#endif
             }
         }
 

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -628,6 +628,7 @@ bool DisplayWidget::loadHDRTexture ( QString texturePath, GLenum type, GLuint te
     return loaded;
 }
 
+#ifdef USE_OPEN_EXR
 //
 // Read an RGBA image using class RgbaInputFile:
 //
@@ -690,6 +691,7 @@ bool DisplayWidget::loadEXRTexture(QString texturePath, GLenum type, GLuint text
     }
     return true;
 }
+#endif
 
 // Qt format image, Qt 5+ loads EXR format on linux
 bool DisplayWidget::loadQtTexture(QString texturePath, GLenum type, GLuint textureID)

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
@@ -23,6 +23,7 @@
 #include <QOpenGLFunctions_3_2_Core>
 #include <QOpenGLFunctions_3_3_Compatibility>
 #include <QOpenGLFunctions_3_3_Core>
+#ifdef USE_OPENGL_4
 #include <QOpenGLFunctions_4_0_Compatibility>
 #include <QOpenGLFunctions_4_0_Core>
 #include <QOpenGLFunctions_4_1_Compatibility>
@@ -35,7 +36,10 @@
 #include <QOpenGLFunctions_4_4_Core>
 #include <QOpenGLFunctions_4_5_Compatibility>
 #include <QOpenGLFunctions_4_5_Core>
+#endif
+#ifdef USE_OPENGL_ES2
 #include <QOpenGLFunctions_ES2>
+#endif
 
 #include <QOpenGLFunctions>
 #include <QOpenGLVersionFunctions>
@@ -95,7 +99,11 @@ class CameraControl;
 #ifdef Q_OS_MAC
 class DisplayWidget : public QOpenGLWidget, protected QOpenGLFunctions
 #else
+#ifdef USE_OPENGL_4
 class DisplayWidget : public QOpenGLWidget, protected QOpenGLFunctions_4_1_Compatibility
+#else
+class DisplayWidget : public QOpenGLWidget, protected QOpenGLFunctions_3_3_Compatibility
+#endif
 #endif
 {
     Q_OBJECT
@@ -351,7 +359,9 @@ private:
     void checkForSpecialCase(QString uniformName, QString &uniformValue);
     void setFloatType(GLenum type, QString &tp);
     bool checkShaderProg(GLuint programID);
+#ifdef USE_OPENGL_4
     void setDoubleType(GLuint programID, GLenum type, QString uniformName, QString uniformValue, bool &foundDouble, QString &tp);
+#endif
     void setupShaderVars(int w, int h);
     void draw3DHints();
     bool FBOcheck();

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
@@ -342,7 +342,9 @@ private:
     bool initPreviewBuffer();
 
     bool loadHDRTexture(QString texturePath, GLenum type, GLuint textureID);
+#ifdef USE_OPEN_EXR
     bool loadEXRTexture(QString texturePath, GLenum type, GLuint textureID);
+#endif
     bool loadQtTexture(QString texturePath, GLenum type, GLuint textureID);
 
     bool setTextureParms(QString textureUniformName, GLenum type);

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
@@ -79,7 +79,7 @@ MainWindow::MainWindow(QSplashScreen *splashWidget)
 
     setFocusPolicy(Qt::WheelFocus);
 
-    version = Version(2, 5, 0, 190723, "");
+    version = Version(2, 5, 0, 1900802, "");
     setAttribute(Qt::WA_DeleteOnClose);
 
     fullScreenEnabled = false;

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
@@ -79,7 +79,7 @@ MainWindow::MainWindow(QSplashScreen *splashWidget)
 
     setFocusPolicy(Qt::WheelFocus);
 
-    version = Version(2, 5, 0, 1900802, "");
+    version = Version(2, 5, 0, 190802, "");
     setAttribute(Qt::WA_DeleteOnClose);
 
     fullScreenEnabled = false;

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
@@ -58,6 +58,7 @@ namespace GUI
 MainWindow::MainWindow(QSplashScreen *splashWidget)
     : splashWidget(splashWidget), cmdScriptDebugger(nullptr)
 {
+    DBOUT;
 
     bufferXSpinBox = nullptr;
     bufferYSpinBox = nullptr;
@@ -109,6 +110,7 @@ MainWindow::MainWindow(QSplashScreen *splashWidget)
 void MainWindow::createCommandHelpMenu(QMenu *menu, QWidget *textEdit,
                                        MainWindow *mainWindow)
 {
+    DBOUT;
     QMenu *preprocessorMenu = new QMenu(tr("Host Preprocessor Commands"), nullptr);
     preprocessorMenu->addAction("#info sometext", textEdit , SLOT(insertText()));
     preprocessorMenu->addAction("#include \"some.frag\"", textEdit, SLOT(insertText()));
@@ -185,6 +187,7 @@ void MainWindow::createCommandHelpMenu(QMenu *menu, QWidget *textEdit,
 
 void MainWindow::closeEvent(QCloseEvent *ev)
 {
+    DBOUT;
     bool modification = false;
     for (auto &i : tabInfo) {
         if (i.unsaved) {
@@ -231,11 +234,13 @@ void MainWindow::closeEvent(QCloseEvent *ev)
 
 void MainWindow::newFile()
 {
+    DBOUT;
     insertTabPage("");
 }
 
 void MainWindow::insertPreset()
 {
+    DBOUT;
     bool ok = false;
     QString newPreset;
     QTextCursor tc = getTextEdit()->textCursor();
@@ -289,6 +294,7 @@ void MainWindow::insertPreset()
 
 void MainWindow::open()
 {
+    DBOUT;
     QString filter = tr("Fragment Source (*.frag);;All Files (*.*)");
     QString fileName =
         QFileDialog::getOpenFileName(this, QString(), QString(), filter);
@@ -299,6 +305,7 @@ void MainWindow::open()
 
 void MainWindow::keyReleaseEvent(QKeyEvent *ev)
 {
+    DBOUT;
 
     if (ev->key() == Qt::Key_Escape) {
         toggleFullScreen();
@@ -321,18 +328,21 @@ void MainWindow::keyReleaseEvent(QKeyEvent *ev)
 
 void MainWindow::clearTextures()
 {
+    DBOUT;
     engine->clearTextureCache(nullptr);
 }
 
 void MainWindow::bufferSpinBoxChanged(int value)
 {
     Q_UNUSED(value)
+    DBOUT;
     QToolTip::showText(bufferSizeControl->pos(), tr("Set combobox to 'custom-size' to apply size."), nullptr);
 }
 
 
 bool MainWindow::save()
 {
+    DBOUT;
     int index = tabBar->currentIndex();
     if (index == -1) {
         WARNING(tr("No open tab"));
@@ -348,6 +358,7 @@ bool MainWindow::save()
 
 bool MainWindow::saveAs()
 {
+    DBOUT;
     int index = tabBar->currentIndex();
     if (index == -1) {
         WARNING(tr("No open tab"));
@@ -372,6 +383,7 @@ bool MainWindow::saveAs()
 
 void MainWindow::showHelpMessage(const QString title, const QString mess)
 {
+    DBOUT;
 
     QMessageBox mb(this);
     mb.setText(mess);
@@ -385,6 +397,7 @@ void MainWindow::showHelpMessage(const QString title, const QString mess)
 
 void MainWindow::about()
 {
+    DBOUT;
     QString text = QString("<!DOCTYPE html><html lang=\"%1\">").arg(langID);
 
     text += tr("<h1>Fragmentarium</h1>"
@@ -415,6 +428,7 @@ void MainWindow::about()
 
 void MainWindow::showControlHelp()
 {
+    DBOUT;
   QString text = QString("<!DOCTYPE html><html lang=\"%1\">").arg(langID);
     text += tr("<p>"
   "Notice: the 3D view must have keyboard focus!"
@@ -466,6 +480,7 @@ void MainWindow::showControlHelp()
 
 void MainWindow::showScriptingHelp()
 {
+    DBOUT;
   QString reqObj = sender()->objectName();
 
   QString text = QString("<!DOCTYPE html><html lang=\"%1\">").arg(langID);
@@ -571,6 +586,7 @@ void MainWindow::showScriptingHelp()
 
 void MainWindow::documentWasModified()
 {
+    DBOUT;
     if (tabBar->currentIndex() < 0) {
         return;
     }
@@ -600,6 +616,7 @@ void MainWindow::documentWasModified()
 
 void MainWindow::init()
 {
+    DBOUT;
     lastTime = new QTime();
     lastTime->start();
 
@@ -742,6 +759,7 @@ initTools();
 #ifdef USE_OPEN_EXR
 void MainWindow::initTools()
 {
+    DBOUT;
 
     QStringList filters;
 
@@ -797,6 +815,7 @@ void MainWindow::initTools()
 
 void MainWindow::runTool()
 {
+    DBOUT;
     QString cmnd = sender()->objectName();
     // execute once with -h option and capture the output
     cmnd += " -h &> .htxt"; // > filename 2>&1
@@ -840,6 +859,7 @@ void MainWindow::runTool()
 
 void MainWindow::showWelcomeNote()
 {
+    DBOUT;
     QString s =
         tr("This is your first run of Fragmentarium.\nPlease read this:\n\n"
         "(1) Fragmentarium requires a decent GPU, preferably a NVIDIA or ATI discrete graphics card with recent drivers.\n\n"
@@ -854,6 +874,7 @@ void MainWindow::showWelcomeNote()
 
 void MainWindow::variablesChanged(bool lockedChanged)
 {
+    DBOUT;
     if (lockedChanged) {
         highlightBuildButton(true);
     }
@@ -862,6 +883,7 @@ void MainWindow::variablesChanged(bool lockedChanged)
 
 void MainWindow::createOpenGLContextMenu()
 {
+    DBOUT;
     openGLContextMenu = new QMenu();
     openGLContextMenu->addAction(fullScreenAction);
     openGLContextMenu->addMenu(fileMenu);
@@ -874,6 +896,7 @@ void MainWindow::createOpenGLContextMenu()
 
 void MainWindow::toggleFullScreen()
 {
+    DBOUT;
     if (fullScreenEnabled) {
         frameMainWindow->setMargin(4);
         showNormal();
@@ -898,6 +921,7 @@ void MainWindow::toggleFullScreen()
 
 void MainWindow::createActions()
 {
+    DBOUT;
     fullScreenAction = new QAction(tr("Fullscreen (ESC key toggles)"), this);
     connect(fullScreenAction, SIGNAL(triggered()), this, SLOT(toggleFullScreen()));
 
@@ -1056,6 +1080,7 @@ void MainWindow::createActions()
 
 void MainWindow::createMenus()
 {
+    DBOUT;
     // -- File Menu --
     fileMenu = menuBar()->addMenu(tr("&File"));
     fileMenu->addAction(newAction);
@@ -1155,6 +1180,7 @@ void MainWindow::createMenus()
 
 void MainWindow::buildExamplesMenu()
 {
+    DBOUT;
     QStringList filters;
     // Scan examples dir...
     QDir d(getExamplesDir());
@@ -1213,6 +1239,7 @@ void MainWindow::buildExamplesMenu()
 QString MainWindow::makeImgFileName(int timeStep, int timeSteps,
                                     const QString fileName)
 {
+    DBOUT;
     QString name = fileName;
 
     if (timeSteps > 1) {
@@ -1234,6 +1261,7 @@ QString MainWindow::makeImgFileName(int timeStep, int timeSteps,
 
 void MainWindow::tileBasedRender()
 {
+    DBOUT;
 
     if (!engine->hasShader()) {
         WARNING(tr("Build the fragment first!"));
@@ -1696,6 +1724,7 @@ retry:
 
 void MainWindow::savePreview()
 {
+    DBOUT;
 
     QDialog *qd;
     if (findChild<QDialog *>("PREVIEW") != 0) {
@@ -1725,6 +1754,7 @@ void MainWindow::savePreview()
 
 void MainWindow::pasteSelected()
 {
+    DBOUT;
     QString settings = getTextEdit()->textCursor().selectedText();
     // Note: If the selection obtained from an editor spans a line break,
     // the text will contain a Unicode U+2029 paragraph separator character
@@ -1737,6 +1767,7 @@ void MainWindow::pasteSelected()
 
 void MainWindow::saveParameters()
 {
+    DBOUT;
     QString filter = tr("Fragment Parameters (*.fragparams);;All Files (*.*)");
     QString fileName = QFileDialog::getSaveFileName(this, tr("Save As"), "", filter);
 
@@ -1746,6 +1777,7 @@ void MainWindow::saveParameters()
 
 void MainWindow::saveParameters(const QString fileName)
 {
+    DBOUT;
 
     if (fileName.isEmpty()) {
         return;
@@ -1764,6 +1796,7 @@ void MainWindow::saveParameters(const QString fileName)
 
 void MainWindow::loadParameters(const QString fileName)
 {
+    DBOUT;
     QFile file(fileName);
     if (fileName.toLower().endsWith(".png") && file.exists()) {
       variableEditor->setSettings(QImage(fileName).text("frAg"));
@@ -1783,6 +1816,7 @@ void MainWindow::loadParameters(const QString fileName)
 
 void MainWindow::loadParameters()
 {
+    DBOUT;
     QString filter = tr("Fragment Parameters (*.fragparams);;All Files (*.*)");
     QString fileName = QFileDialog::getOpenFileName(this, tr("Load"), "", filter);
     if (fileName.isEmpty()) {
@@ -1794,6 +1828,7 @@ void MainWindow::loadParameters()
 
 void MainWindow::createToolBars()
 {
+    DBOUT;
     fileToolBar = addToolBar(tr("File Toolbar"));
     fileToolBar->addAction(newAction);
     fileToolBar->addAction(openAction);
@@ -1939,6 +1974,7 @@ void MainWindow::createToolBars()
 
 void MainWindow::setTimeSliderValue(int value)
 {
+    DBOUT;
     // timeslider max = animation length in frames set here to keep in sync with framerate/duration changes
     timeSlider->setMaximum(timeMaxSpinBox->value()*renderFPS);
 
@@ -1959,6 +1995,7 @@ void MainWindow::setTimeSliderValue(int value)
 
 void MainWindow::bufferActionChanged(QAction *action)
 {
+    DBOUT;
     bufferSizeControl->setText(action->text());
     if (action == bufferAction1) {
         bufferSizeMultiplier = 1;
@@ -1976,6 +2013,7 @@ void MainWindow::bufferActionChanged(QAction *action)
 
 void MainWindow::timeLineRequest(QPoint p)
 {
+    DBOUT;
     Q_UNUSED(p)
     auto *timeDialog = new TimeLineDialog(this);
     timeDialog->setWindowTitle(strippedName(tabInfo[tabBar->currentIndex()].filename));
@@ -1985,6 +2023,7 @@ void MainWindow::timeLineRequest(QPoint p)
 
 void MainWindow::videoEncoderRequest()
 {
+    DBOUT;
     auto *vDialog = new VideoDialog(this);
     vDialog->exec();
 
@@ -1992,6 +2031,7 @@ void MainWindow::videoEncoderRequest()
 
 void MainWindow::timeChanged(int value)
 {
+    DBOUT;
     Q_UNUSED(value)
     lastTime->restart();
     lastStoredTime = getTimeSliderValue();
@@ -2001,6 +2041,7 @@ void MainWindow::timeChanged(int value)
 
 void MainWindow::timeMaxChanged(int value)
 {
+    DBOUT;
     lastTime->restart();
     lastStoredTime = getTimeSliderValue();
     getTime();
@@ -2015,6 +2056,7 @@ void MainWindow::timeMaxChanged(int value)
 
 void MainWindow::rewind()
 {
+    DBOUT;
     lastTime->restart();
     lastStoredTime = 0;
     getTime();
@@ -2023,6 +2065,7 @@ void MainWindow::rewind()
 
 void MainWindow::play()
 {
+    DBOUT;
     playAction->setEnabled(false);
     stopAction->setEnabled(true);
     lastTime->restart();
@@ -2033,7 +2076,7 @@ void MainWindow::play()
 
 void MainWindow::stop()
 {
-
+    DBOUT;
     playAction->setEnabled(true);
     stopAction->setEnabled(false);
     lastStoredTime = getTime();
@@ -2050,16 +2093,19 @@ void MainWindow::stop()
 
 void MainWindow::maxSubSamplesChanged(int value)
 {
+    DBOUT;
     engine->setMaxSubFrames(value);
 }
 
 void MainWindow::setSubframeMax(int i)
 {
+    DBOUT;
     frameSpinBox->setValue(i);
 }
 
 double MainWindow::getTime()
 {
+    DBOUT;
     DisplayWidget::DrawingState state = engine->getState();
 
     int time = 0;
@@ -2087,6 +2133,7 @@ double MainWindow::getTime()
 
 void MainWindow::renderModeChanged()
 {
+    DBOUT;
     engine->setMaxSubFrames(frameSpinBox->value());
     setFPS(-1);
     QObject* o = QObject::sender();
@@ -2106,11 +2153,13 @@ void MainWindow::renderModeChanged()
 
 void MainWindow::setSubFrameDisplay(int i)
 {
+    DBOUT;
     frameLabel->setText(QString(" %1 %2").arg(tr("Done")).arg(i));
 }
 
 void MainWindow::callRedraw()
 {
+    DBOUT;
     bool state = engine->isRedrawDisabled();
     engine->setDisableRedraw(false);
     engine->setDisableRedraw(state);
@@ -2118,6 +2167,7 @@ void MainWindow::callRedraw()
 
 void MainWindow::disableAllExcept(QWidget *w)
 {
+    DBOUT;
     disabledWidgets.clear();
     disabledWidgets = findChildren<QWidget *>("");
     while (w != nullptr) {
@@ -2133,11 +2183,13 @@ void MainWindow::disableAllExcept(QWidget *w)
 
 void MainWindow::createStatusBar()
 {
+    DBOUT;
     statusBar()->showMessage(tr("Ready"));
 }
 
 void MainWindow::readSettings()
 {
+    DBOUT;
     QSettings settings;
     maxRecentFiles = settings.value("maxRecentFiles", 5).toInt();
     renderFPS = settings.value("fps", 25).toInt();
@@ -2163,6 +2215,7 @@ void MainWindow::readSettings()
 
 void MainWindow::writeSettings()
 {
+    DBOUT;
     QSettings settings;
     settings.setValue("geometry", saveGeometry());
     settings.setValue("windowState", saveState());
@@ -2200,6 +2253,7 @@ void MainWindow::writeSettings()
 
 void MainWindow::openFile()
 {
+    DBOUT;
     auto *action = qobject_cast<QAction *>(sender());
     if (action != nullptr) {
         loadFragFile(action->data().toString());
@@ -2210,12 +2264,14 @@ void MainWindow::openFile()
 
 void MainWindow::reloadFrag()
 {
+    DBOUT;
     int index = tabBar->currentIndex();
     reloadFragFile( index );
 }
 
 void MainWindow::reloadFragFile( int index )
 {
+    DBOUT;
     QString filename = tabInfo[index].filename;
     TextEdit* te = getTextEdit();
 
@@ -2236,6 +2292,7 @@ void MainWindow::reloadFragFile( int index )
 /// fragWatch
 void MainWindow::reloadFragFile( QString f )
 {
+    DBOUT;
     static bool first = true; // TODO: why this gets called twice ???
 
     bool autoLoad = QSettings().value("autoload", false).toBool();
@@ -2277,6 +2334,7 @@ void MainWindow::reloadFragFile( QString f )
 
 void MainWindow::loadFragFile(const QString &fileName)
 {
+    DBOUT;
     // calling with nonexistant filename before test prevents crash
     // fi a non-quoted filename with an unescaped space will appear as 2 file
     // names, both are wrong the first appears as non frag the second appears as
@@ -2320,6 +2378,7 @@ update();
 
 bool MainWindow::saveFile(const QString &fileName)
 {
+    DBOUT;
     if (tabBar->currentIndex() == -1) {
         WARNING(tr("No open tab"));
         return false;
@@ -2361,11 +2420,13 @@ bool MainWindow::saveFile(const QString &fileName)
 
 QString MainWindow::strippedName(const QString &fullFileName)
 {
+    DBOUT;
     return QFileInfo(fullFileName).fileName();
 }
 
 void MainWindow::showPreprocessedScript()
 {
+    DBOUT;
 
     logger->getListWidget()->clear();
     if (tabBar->currentIndex() == -1) {
@@ -2407,6 +2468,7 @@ void MainWindow::showPreprocessedScript()
 
 void MainWindow::highlightBuildButton(bool value)
 {
+    DBOUT;
     QWidget* w = buildLabel->parentWidget();
     if (value) {
         QPalette pal = buildLabel->palette();
@@ -2426,6 +2488,7 @@ void MainWindow::highlightBuildButton(bool value)
 
 void MainWindow::addToWatch(QStringList fileList)
 {
+    DBOUT;
     foreach(QString f, fileList) {
         if(QFile(f).exists() && !fragWatch->files().contains(f)) {
             fragWatch->addPaths(fileList);
@@ -2435,6 +2498,7 @@ void MainWindow::addToWatch(QStringList fileList)
 
 bool MainWindow::initializeFragment()
 {
+    DBOUT;
     if (tabBar->currentIndex() == -1) {
         WARNING(tr("No open tab"));
         return false;
@@ -2555,6 +2619,7 @@ bool MainWindow::initializeFragment()
 
 void MainWindow::hideUnusedVariableWidgets()
 {
+    DBOUT;
     /// hide unused widgets unless the default state is locked
     QStringList wnames = variableEditor->getWidgetNames();
     for (int i = 0; i < wnames.count(); i++) {
@@ -2587,6 +2652,7 @@ namespace
 // Returns the first valid directory.
 QString findDirectory(QStringList guesses)
 {
+    DBOUT;
     QStringList invalid;
     for (int i = 0; i < guesses.size(); i++) {
         if (QFile::exists(guesses[i])) {
@@ -2604,6 +2670,7 @@ QString findDirectory(QStringList guesses)
 // Mac needs to step two directories up, when debugging in XCode...
 QString MainWindow::getExamplesDir()
 {
+    DBOUT;
     QStringList examplesDir;
     examplesDir << "Examples"
                 << "../Examples"
@@ -2614,6 +2681,7 @@ QString MainWindow::getExamplesDir()
 
 QString MainWindow::getMiscDir()
 {
+    DBOUT;
     QStringList miscDir;
     miscDir << "Misc"
             << "../Misc"
@@ -2624,30 +2692,32 @@ QString MainWindow::getMiscDir()
 
 TextEdit *MainWindow::getTextEdit()
 {
+    DBOUT;
     return (TextEdit *)stackedTextEdits->currentWidget();
 }
 
 void MainWindow::cursorPositionChanged()
 {
-    TextEdit *te = this->getTextEdit();
-    if (te == nullptr) {
+    DBOUT;
+    TextEdit *te = getTextEdit();
+
+    if (te == 0) {
         return;
     }
+
     int pos = te->textCursor().position();
     int blockNumber = te->textCursor().blockNumber();
-
     // Do reverse look up...
     FragmentSource* fs = engine->getFragmentSource();
     QString x;
     QStringList ex;
     QString filename = tabInfo[tabBar->currentIndex()].filename;
-
     // when there is no #version statement as the first line the line number is off by 2
     // default is to insert #version statements into vertex shaders (both makes 2) so they match the fragment shaders
 
     int incFudge = 0;
+    if (!(fs->source.count())) return;
     if( !fs->source.at(0).contains("#version") ) incFudge = 2;
-
     for (int i = 0; i < fs->lines.count(); i++) {
         // fs->sourceFiles[fs->sourceFile[i]]->fileName()
         if (fs->lines[i] == blockNumber && QString::compare(filename, fs->sourceFileNames[fs->sourceFile[i]], Qt::CaseInsensitive) == 0) {
@@ -2665,6 +2735,7 @@ void MainWindow::cursorPositionChanged()
 
 TextEdit *MainWindow::insertTabPage(QString filename)
 {
+    DBOUT;
     auto *textEdit = new TextEdit(this);
     textEdit->setStyleSheet(editorStylesheet);
 
@@ -2754,11 +2825,13 @@ Up = -0.1207781,0.8478234,0.5163409\r\n\
 
 void MainWindow::resetCamera(bool fullReset)
 {
+    DBOUT;
     engine->resetCamera(fullReset);
 }
 
 void MainWindow::tabChanged(int index)
 {
+    DBOUT;
     if (index > tabInfo.size()) {
         return;
     }
@@ -2798,6 +2871,7 @@ void MainWindow::tabChanged(int index)
 
 void MainWindow::closeTab()
 {
+    DBOUT;
     if (tabBar->currentIndex() == -1) {
         WARNING(tr("No open tab"));
         return;
@@ -2808,7 +2882,7 @@ void MainWindow::closeTab()
 
 void MainWindow::closeTab(int index)
 {
-
+    DBOUT;
     TabInfo t = tabInfo[index];
     if (t.unsaved) {
         QString mess =
@@ -2845,6 +2919,7 @@ void MainWindow::closeTab(int index)
 
 void MainWindow::clearKeyFrames()
 {
+    DBOUT;
     // clear the easingcurve settings
     if(variableEditor->hasEasing()) {
         engine->setCurveSettings( QStringList() );
@@ -2858,6 +2933,7 @@ void MainWindow::clearKeyFrames()
 
 void MainWindow::launchDocumentation()
 {
+    DBOUT;
     INFO(tr("Launching web browser..."));
     bool s = QDesktopServices::openUrl(QUrl("https://en.wikibooks.org/wiki/Fractals/fragmentarium"));
     if (!s) {
@@ -2867,6 +2943,7 @@ void MainWindow::launchDocumentation()
 
 void MainWindow::launchSfHome()
 {
+    DBOUT;
     INFO(tr("Launching web browser..."));
     bool s = QDesktopServices::openUrl(QUrl("http://syntopia.github.com/Fragmentarium/"));
     if (!s) {
@@ -2876,6 +2953,7 @@ void MainWindow::launchSfHome()
 
 void MainWindow::launchGLSLSpecs()
 {
+    DBOUT;
     INFO(tr("Launching web browser..."));
     bool s = QDesktopServices::openUrl(QUrl("http://www.opengl.org/registry/"));
     if (!s) {
@@ -2885,6 +2963,7 @@ void MainWindow::launchGLSLSpecs()
 
 void MainWindow::launchIntro()
 {
+    DBOUT;
     INFO("Launching web browser...");
     bool s = QDesktopServices::openUrl(QUrl("http://blog.hvidtfeldts.net/index.php/2011/06/distance-estimated-3d-fractals-part-i/"));
     if (!s) {
@@ -2894,6 +2973,7 @@ void MainWindow::launchIntro()
 
 void MainWindow::launchFAQ()
 {
+    DBOUT;
     INFO("Launching web browser...");
     bool s = QDesktopServices::openUrl(QUrl("http://blog.hvidtfeldts.net/index.php/2011/12/fragmentarium-faq/"));
     if (!s) {
@@ -2903,6 +2983,7 @@ void MainWindow::launchFAQ()
 
 void MainWindow::launchReferenceHome()
 {
+    DBOUT;
     INFO("Launching web browser...");
     bool s = QDesktopServices::openUrl(QUrl("http://www.fractalforums.com/fragmentarium/"));
     if (!s) {
@@ -2912,6 +2993,7 @@ void MainWindow::launchReferenceHome()
 
 void MainWindow::launchReferenceHome2()
 {
+    DBOUT;
     INFO("Launching web browser...");
     bool s = QDesktopServices::openUrl(QUrl("http://www.digilanti.org/fragmentarium/"));
     if (!s) {
@@ -2921,6 +3003,7 @@ void MainWindow::launchReferenceHome2()
 
 void MainWindow::launchGallery()
 {
+    DBOUT;
     INFO("Launching web browser...");
     bool s = QDesktopServices::openUrl(QUrl("http://flickr.com/groups/fragmentarium/"));
     if (!s) {
@@ -2930,12 +3013,14 @@ void MainWindow::launchGallery()
 
 void MainWindow::makeScreenshot()
 {
+    DBOUT;
     engine->update();
     saveImage(engine->grabFramebuffer());
 }
 
 void MainWindow::saveImage(QImage image)
 {
+    DBOUT;
     QString filename = GetImageFileName(this, tr("Save screenshot as:"));
     if (filename.isEmpty()) {
         return;
@@ -2953,6 +3038,7 @@ void MainWindow::saveImage(QImage image)
 
 void MainWindow::copy()
 {
+    DBOUT;
     if (tabBar->currentIndex() == -1) {
         WARNING(tr("No open tab"));
         return;
@@ -2962,6 +3048,7 @@ void MainWindow::copy()
 
 void MainWindow::cut()
 {
+    DBOUT;
     if (tabBar->currentIndex() == -1) {
         WARNING(tr("No open tab"));
         return;
@@ -2971,6 +3058,7 @@ void MainWindow::cut()
 
 void MainWindow::paste()
 {
+    DBOUT;
     if (tabBar->currentIndex() == -1) {
         WARNING(tr("No open tab"));
         return;
@@ -2980,6 +3068,7 @@ void MainWindow::paste()
 
 void MainWindow::search()
 {
+    DBOUT;
     if (tabBar->currentIndex() == -1) {
         WARNING(tr("No open tab"));
         return;
@@ -3008,6 +3097,7 @@ restart:
 
 void MainWindow::dragEnterEvent(QDragEnterEvent *ev)
 {
+    DBOUT;
     if (ev->mimeData()->hasUrls()) {
         ev->acceptProposedAction();
     } else {
@@ -3017,6 +3107,7 @@ void MainWindow::dragEnterEvent(QDragEnterEvent *ev)
 
 void MainWindow::dropEvent(QDropEvent *ev)
 {
+    DBOUT;
     if (ev->mimeData()->hasUrls() && ev->source() == nullptr) {
         QList<QUrl> urls = ev->mimeData()->urls();
         for (auto &url : urls) {
@@ -3053,6 +3144,7 @@ void MainWindow::dropEvent(QDropEvent *ev)
 
 void MainWindow::setRecentFile(const QString &fileName)
 {
+    DBOUT;
     QSettings settings;
 
     QStringList files = settings.value("recentFileList").toStringList();
@@ -3088,6 +3180,7 @@ void MainWindow::setRecentFile(const QString &fileName)
 
 void MainWindow::setSplashWidgetTimeout(QSplashScreen *w)
 {
+    DBOUT;
     splashWidget = w;
     QTimer::singleShot(2000, this, SLOT(removeSplash()));
     // test for nVidia card and GL > 4.0
@@ -3102,6 +3195,7 @@ void MainWindow::setSplashWidgetTimeout(QSplashScreen *w)
 
 void MainWindow::removeSplash()
 {
+    DBOUT;
     if (splashWidget != nullptr) {
         splashWidget->finish(this);
     }
@@ -3110,6 +3204,7 @@ void MainWindow::removeSplash()
 
 void MainWindow::insertText()
 {
+    DBOUT;
     if (tabBar->currentIndex() == -1) {
         WARNING(tr("No open tab"));
         return;
@@ -3121,6 +3216,7 @@ void MainWindow::insertText()
 
 void MainWindow::preferences()
 {
+    DBOUT;
     PreferencesDialog pd(this);
     pd.exec();
     readSettings();
@@ -3141,6 +3237,7 @@ initTools();
 
 void MainWindow::getBufferSize(int w, int h, int &bufferSizeX, int &bufferSizeY, bool &fitWindow)
 {
+    DBOUT;
     if (engine != nullptr && engine->getState() == DisplayWidget::Tiled) {
         bufferSizeX = bufferXSpinBox->value();
         bufferSizeY =  bufferYSpinBox->value();
@@ -3185,6 +3282,7 @@ void MainWindow::getBufferSize(int w, int h, int &bufferSizeX, int &bufferSizeY,
 
 void MainWindow::indent()
 {
+    DBOUT;
     if (tabBar->currentIndex() == -1) {
         WARNING(tr("No open tab"));
         return;
@@ -3218,6 +3316,7 @@ void MainWindow::indent()
 
 void MainWindow::setFPS(float fps)
 {
+    DBOUT;
     if (fps>0) {
         fpsLabel->setText("FPS: " + QString::number(fps, 'f', 1) + " (" + QString::number(1.0 / fps, 'g', 1) + "s)");
     } else {
@@ -3227,6 +3326,7 @@ void MainWindow::setFPS(float fps)
 
 QString MainWindow::getCameraSettings()
 {
+    DBOUT;
     QString settings = variableEditor->getSettings();
     QStringList l = settings.split("\n");
     QStringList r;
@@ -3242,6 +3342,7 @@ QString MainWindow::getCameraSettings()
 
 void MainWindow::setCameraSettings(QVector3D e, QVector3D t, QVector3D u)
 {
+    DBOUT;
     QString r = QString("Eye = %1,%2,%3\nTarget = %4,%5,%6\nUp = %7,%8,%9\n")
                 .arg(e.x()).arg(e.y()).arg(e.z())
                 .arg(t.x()).arg(t.y()).arg(t.z())
@@ -3262,6 +3363,7 @@ void MainWindow::setCameraSettings(QVector3D e, QVector3D t, QVector3D u)
 
 QString MainWindow::getPresetNames(bool keyframesORpresets)
 {
+    DBOUT;
     int c = variableEditor->getPresetCount(); // total preset count including keyframes
     QStringList k, p;
     if (c > 1) {
@@ -3281,7 +3383,7 @@ QString MainWindow::getPresetNames(bool keyframesORpresets)
 
 void MainWindow::initKeyFrameControl()
 {
-
+    DBOUT;
     if (engine->eyeSpline != nullptr || engine->targetSpline != nullptr || engine->upSpline != nullptr) {
         clearKeyFrameControl();
     }
@@ -3318,6 +3420,7 @@ void MainWindow::initKeyFrameControl()
 
 void MainWindow::clearKeyFrameControl()
 {
+    DBOUT;
     variableEditor->setKeyFramesEnabled(false);
     if (engine->eyeSpline != nullptr || engine->targetSpline != nullptr || engine->upSpline != nullptr) {
         engine->clearControlPoints();
@@ -3332,6 +3435,7 @@ void MainWindow::clearKeyFrameControl()
 
 void MainWindow::addKeyFrame(QStringList kfps)
 {
+    DBOUT;
     /// for each key frame add ctrl point to the list
     if(engine->cameraID() == "3D" ) {
         KeyFrameInfo kf(kfps);
@@ -3345,7 +3449,7 @@ void MainWindow::addKeyFrame(QStringList kfps)
 
 void MainWindow::selectPreset()
 {
-
+    DBOUT;
     QString pName;
 
     pName = QString("#preset %1").arg(variableEditor->getPresetName());
@@ -3375,6 +3479,7 @@ void MainWindow::selectPreset()
 
 void MainWindow::processGuiEvents()
 {
+    DBOUT;
   // Immediately dispatches all queued events
   qApp->sendPostedEvents();
   // Processes all pending events until there are no more events to process
@@ -3384,6 +3489,7 @@ void MainWindow::processGuiEvents()
 
 void MainWindow::dumpShaderAsm()
 {
+    DBOUT;
     if (engine->hasShader()) {
         AsmBrowser::showPage(engine->shaderAsm(true), "Rendershader Program");
     }
@@ -3394,7 +3500,7 @@ void MainWindow::dumpShaderAsm()
 
 void MainWindow::saveCmdScript()
 {
-
+    DBOUT;
     auto *e = sender()->parent()->findChild<QTextEdit *>("cmdScriptEditor", Qt::FindChildrenRecursively);
     scriptText = e->toPlainText();
 
@@ -3421,6 +3527,7 @@ void MainWindow::saveCmdScript()
 
 void MainWindow::loadCmdScript()
 {
+    DBOUT;
     QString filter = tr("Cmd Script (*.fqs);;All Files (*.*)");
     QString fileName = QFileDialog::getOpenFileName(this, QString(), QString(), filter);
     QSettings settings;
@@ -3450,7 +3557,7 @@ void MainWindow::loadCmdScript()
 
 void MainWindow::editScript()
 {
-
+    DBOUT;
     if (scriptText.isEmpty()) {
         loadCmdScript();
     }
@@ -3515,6 +3622,7 @@ void MainWindow::editScript()
 
 void MainWindow::executeScript()
 {
+    DBOUT;
     QTextEdit *e = nullptr;
 
     QSettings settings;
@@ -3568,6 +3676,7 @@ void MainWindow::executeScript()
 
 void MainWindow::setupScriptEngine()
 {
+    DBOUT;
     runningScript=false;
     // expose these widgets to the script
     appContext = scriptEngine.newQObject(this);

--- a/Fragmentarium-Source/Fragmentarium/Parser/Preprocessor.h
+++ b/Fragmentarium-Source/Fragmentarium/Parser/Preprocessor.h
@@ -16,11 +16,13 @@
 #include "../../SyntopiaCore/Exceptions/Exception.h"
 #include "../../SyntopiaCore/Logging/Logging.h"
 
+#define DBOUT
+// qDebug() << QString(__FILE__).split(QDir::separator()).last() << __LINE__ << __FUNCTION__
+
 namespace Fragmentarium {
 using namespace GUI;
 
 namespace Parser {
-#define DBOUT   qDebug() << QString(__FILE__).split(QDir::separator()).last() << __LINE__ << __FUNCTION__
 
 using namespace SyntopiaCore::Logging;
 


### PR DESCRIPTION
Not ready to be merged yet, comments appreciated.

This enables OpenGL 3.3 Compatibility profle support at compile time, by wrapping all the OpenGL 4 specific parts in `#ifdef USE_OPENGL_4`.

However, there is currently no way to `#define USE_OPENGL_4` in the build system, I need to learn more about CMake to fix that.

It is a compile time flag because of the inheritance from `QOpenGLFunctions` etc.  Maybe there would be a way to dynamically switch between creating one or the other at runtime, I don't know Qt so I don't know what is possible.

Thoughts?