### PR TITLE
[bugfix] vector precision

### DIFF
--- a/Fragmentarium-Source/Fragmentarium/GUI/CameraControl.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/CameraControl.cpp
@@ -201,7 +201,7 @@ bool Camera3D::parseKeys()
 
     if (keyDown(Qt::Key_Y)) {
         glm::dmat4 m = glm::identity<glm::dmat4>();
-        m = rotate(m, factor, upV);
+        m = rotate(m, glm::radians(factor), upV);
         target->setValue(m * direction + eye->getValue());
         up->setValue(m * up->getValue());
         keysDown = true;
@@ -209,7 +209,7 @@ bool Camera3D::parseKeys()
 
     if (keyDown(Qt::Key_H)) {
         glm::dmat4 m = glm::identity<glm::dmat4>();
-        m = rotate(m, -factor, upV);
+        m = rotate(m, glm::radians(-factor), upV);
         target->setValue(m * direction + eye->getValue());
         up->setValue(m * up->getValue());
         keysDown = true;
@@ -217,7 +217,7 @@ bool Camera3D::parseKeys()
 
     if (keyDown(Qt::Key_T)) {
         glm::dmat4 m = glm::identity<glm::dmat4>();
-        m = rotate(m, factor, right);
+        m = rotate(m, glm::radians(factor), right);
         target->setValue(m * direction + eye->getValue());
         up->setValue(m * up->getValue());
         keysDown = true;
@@ -225,7 +225,7 @@ bool Camera3D::parseKeys()
 
     if (keyDown(Qt::Key_G)) {
         glm::dmat4 m = glm::identity<glm::dmat4>();
-        m = rotate(m, -factor, right);
+        m = rotate(m, glm::radians(-factor), right);
         target->setValue(m * direction + eye->getValue());
         up->setValue(m * up->getValue());
         keysDown = true;
@@ -233,7 +233,7 @@ bool Camera3D::parseKeys()
 
     if (keyDown(Qt::Key_E)) {
         glm::dmat4 m = glm::identity<glm::dmat4>();
-        m = rotate(m, factor, dir);
+        m = rotate(m, glm::radians(factor), dir);
         target->setValue(m * direction + eye->getValue());
         up->setValue(m * up->getValue());
         keysDown = true;
@@ -241,7 +241,7 @@ bool Camera3D::parseKeys()
 
     if (keyDown(Qt::Key_Q)) {
         glm::dmat4 m = glm::identity<glm::dmat4>();
-        m = rotate(m, -factor, dir);
+        m = rotate(m, glm::radians(-factor), dir);
         target->setValue(m * direction + eye->getValue());
         up->setValue(m * up->getValue());
         keysDown = true;
@@ -324,9 +324,9 @@ bool Camera3D::mouseEvent(QMouseEvent *e, int w, int h)
             if (QApplication::keyboardModifiers() == Qt::ShiftModifier) {
                 // Rotate about origo
                 glm::dmat4 mx = glm::identity<glm::dmat4>();
-                mx = rotate(mx, -dp.x * mouseSpeed * 10.0, upDown);
+                mx = rotate(mx, glm::radians(-dp.x * mouseSpeed * 10.0), upDown);
                 glm::dmat4 my = glm::identity<glm::dmat4>();
-                my = rotate(my, -dp.y * mouseSpeed * 10.0, rightDown);
+                my = rotate(my, glm::radians(-dp.y * mouseSpeed * 10.0), rightDown);
                 glm::dvec3 oDir = (my * mx) * (-eyeDown);
                 eye->setValue(-oDir);
                 target->setValue((my * mx)*directionDown - oDir);
@@ -334,9 +334,9 @@ bool Camera3D::mouseEvent(QMouseEvent *e, int w, int h)
             } else if (QApplication::keyboardModifiers() == Qt::ShiftModifier + Qt::AltModifier) {
                 // Rotate around target thanks to M.Benesi
                 glm::dmat4 mx = glm::identity<glm::dmat4>();
-                mx = rotate(mx, -dp.x * mouseSpeed * 10.0, upDown);
+                mx = rotate(mx, glm::radians(-dp.x * mouseSpeed * 10.0), upDown);
                 glm::dmat4 my = glm::identity<glm::dmat4>();
-                my = rotate(my, -dp.y * mouseSpeed * 10.0, rightDown);
+                my = rotate(my, glm::radians(-dp.y * mouseSpeed * 10.0), rightDown);
                 glm::dvec3 oDir = (my * mx) * (directionDown); //was -eyeDown
                 eye->setValue(targetDown - oDir);
                 // target->setValue( (my*mx)*directionDown-oDir);
@@ -344,9 +344,9 @@ bool Camera3D::mouseEvent(QMouseEvent *e, int w, int h)
             } else if (QApplication::keyboardModifiers() == Qt::NoModifier) {
                 // orient camera
                 glm::dmat4 mx = glm::identity<glm::dmat4>();
-                mx = rotate(mx, -dp.x * mouseSpeed * 100.0, upDown);
+                mx = rotate(mx, glm::radians(-dp.x * mouseSpeed * 100.0), upDown);
                 glm::dmat4 my = glm::identity<glm::dmat4>();
-                my = rotate(my, -dp.y * mouseSpeed * 100.0, rightDown);
+                my = rotate(my, glm::radians(-dp.y * mouseSpeed * 100.0), rightDown);
                 target->setValue((my * mx) * directionDown + eye->getValue()); // before: eyeDown
                 up->setValue((my * mx)*upDown);
             }

--- a/Fragmentarium-Source/Fragmentarium/GUI/CameraControl.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/CameraControl.cpp
@@ -1,18 +1,19 @@
-
-#include <QMatrix4x4>
-#include <QMatrix>
 #include <QMenu>
 #include <QStatusBar>
 #include <QToolTip>
-#include <QVector2D>
-#include <QVector3D>
-#include <QVector4D>
+#include <glm/glm.hpp>
+#include <glm/ext/matrix_transform.hpp>
 #include <QWheelEvent>
 #include <QFileInfo>
 
 #include "CameraControl.h"
 #include "MainWindow.h"
 #include "VariableWidget.h"
+
+static glm::dvec3 operator*(const glm::dmat4 &m, const glm::dvec3 &v)
+{
+    return glm::dvec3(m * glm::dvec4(v, 0.0));
+}
 
 using namespace SyntopiaCore::Logging;
 
@@ -63,11 +64,11 @@ Camera3D::Camera3D(QStatusBar *statusBar) : statusBar(statusBar)
     target = nullptr;
     up = nullptr;
     fov = nullptr;
-    eyeDown = QVector3D(0, 0, -1);
-    targetDown = QVector3D(0, 0, -1);
-    upDown = QVector3D(0, 0, -1);
+    eyeDown = glm::dvec3(0, 0, -1);
+    targetDown = glm::dvec3(0, 0, -1);
+    upDown = glm::dvec3(0, 0, -1);
     fovDown = 0.0;
-    mouseDown = QVector3D(0, 0, -1);
+    mouseDown = glm::dvec3(0, 0, -1);
 
     keyStatus.clear();
     stepSize = 0.1f;
@@ -123,10 +124,10 @@ bool Camera3D::parseKeys()
     }
 
     //INFO("Parse keys...");
-    QVector3D direction = (target->getValue() - eye->getValue());
-    QVector3D dir = direction.normalized();
-    QVector3D right = QVector3D::crossProduct(direction.normalized(), up->getValue()).normalized();
-    QVector3D upV = up->getValue();
+    glm::dvec3 direction = (target->getValue() - eye->getValue());
+    glm::dvec3 dir = normalize(direction);
+    glm::dvec3 right = normalize(cross(dir, up->getValue()));
+    glm::dvec3 upV = up->getValue();
 
     double factor = stepSize * 10.0;
 
@@ -156,91 +157,91 @@ bool Camera3D::parseKeys()
     }
 
     if (keyDown(Qt::Key_A)) {
-        QVector3D offset = -right * stepSize;
+        glm::dvec3 offset = -right * stepSize;
         eye->setValue(eye->getValue() + offset);
         target->setValue(target->getValue() + offset);
         keysDown = true;
     }
 
     if (keyDown(Qt::Key_D)) {
-        QVector3D offset = right * stepSize;
+        glm::dvec3 offset = right * stepSize;
         eye->setValue(eye->getValue() + offset);
         target->setValue(target->getValue() + offset);
         keysDown = true;
     }
 
     if (keyDown(Qt::Key_W)) {
-        QVector3D offset = dir * stepSize;
-        QVector3D db2 = eye->getValue() + offset;
+        glm::dvec3 offset = dir * stepSize;
+        glm::dvec3 db2 = eye->getValue() + offset;
         eye->setValue(db2);
         target->setValue(target->getValue() + offset);
         keysDown = true;
     }
 
     if (keyDown(Qt::Key_S)) {
-        QVector3D offset = -dir * stepSize;
+        glm::dvec3 offset = -dir * stepSize;
         eye->setValue(eye->getValue() + offset);
         target->setValue(target->getValue() + offset);
         keysDown = true;
     }
 
     if (keyDown(Qt::Key_R)) {
-        QVector3D offset = -upV * stepSize;
+        glm::dvec3 offset = -upV * stepSize;
         eye->setValue(eye->getValue() + offset);
         target->setValue(target->getValue() + offset);
         keysDown = true;
     }
 
     if (keyDown(Qt::Key_F)) {
-        QVector3D offset = upV * stepSize;
+        glm::dvec3 offset = upV * stepSize;
         eye->setValue(eye->getValue() + offset);
         target->setValue(target->getValue() + offset);
         keysDown = true;
     }
 
     if (keyDown(Qt::Key_Y)) {
-        QMatrix4x4 m;
-        m.rotate(factor, upV);
+        glm::dmat4 m = glm::identity<glm::dmat4>();
+        m = rotate(m, factor, upV);
         target->setValue(m * direction + eye->getValue());
         up->setValue(m * up->getValue());
         keysDown = true;
     }
 
     if (keyDown(Qt::Key_H)) {
-        QMatrix4x4 m;
-        m.rotate(-factor, upV);
+        glm::dmat4 m = glm::identity<glm::dmat4>();
+        m = rotate(m, -factor, upV);
         target->setValue(m * direction + eye->getValue());
         up->setValue(m * up->getValue());
         keysDown = true;
     }
 
     if (keyDown(Qt::Key_T)) {
-        QMatrix4x4 m;
-        m.rotate(factor, right);
+        glm::dmat4 m = glm::identity<glm::dmat4>();
+        m = rotate(m, factor, right);
         target->setValue(m * direction + eye->getValue());
         up->setValue(m * up->getValue());
         keysDown = true;
     }
 
     if (keyDown(Qt::Key_G)) {
-        QMatrix4x4 m;
-        m.rotate(-factor, right);
+        glm::dmat4 m = glm::identity<glm::dmat4>();
+        m = rotate(m, -factor, right);
         target->setValue(m * direction + eye->getValue());
         up->setValue(m * up->getValue());
         keysDown = true;
     }
 
     if (keyDown(Qt::Key_E)) {
-        QMatrix4x4 m;
-        m.rotate(factor, dir);
+        glm::dmat4 m = glm::identity<glm::dmat4>();
+        m = rotate(m, factor, dir);
         target->setValue(m * direction + eye->getValue());
         up->setValue(m * up->getValue());
         keysDown = true;
     }
 
     if (keyDown(Qt::Key_Q)) {
-        QMatrix4x4 m;
-        m.rotate(-factor, dir);
+        glm::dmat4 m = glm::identity<glm::dmat4>();
+        m = rotate(m, -factor, dir);
         target->setValue(m * direction + eye->getValue());
         up->setValue(m * up->getValue());
         keysDown = true;
@@ -273,8 +274,8 @@ void Camera3D::orthogonalizeUpVector()
     if (up == nullptr || target == nullptr || eye == nullptr || fov == nullptr) {
         return;
     }
-    QVector3D dir = (target->getValue() - eye->getValue()).normalized();
-    QVector3D fixedUp = up->getValue() - QVector3D::dotProduct(up->getValue(), dir) * dir;
+    glm::dvec3 dir = normalize(target->getValue() - eye->getValue());
+    glm::dvec3 fixedUp = up->getValue() - dot(up->getValue(), dir) * dir;
     up->setValue(fixedUp);
 }
 
@@ -283,9 +284,9 @@ bool Camera3D::mouseEvent(QMouseEvent *e, int w, int h)
     if (up == nullptr || target == nullptr || eye == nullptr || fov == nullptr) {
         return false;
     }
-    QVector3D pos = QVector3D(e->pos().x() / (float(w)), e->pos().y() / (float(h)), 0.0);
-    //QVector3D direction = (target->getValue()-eye->getValue());
-    // QVector3D right = QVector3D::cross(direction.normalized(), up->getValue()).normalized();
+    glm::dvec3 pos = glm::dvec3(e->pos().x() / (float(w)), e->pos().y() / (float(h)), 0.0);
+    //glm::dvec3 direction = (target->getValue()-eye->getValue());
+    // glm::dvec3 right = glm::dvec3::cross(direction.normalized(), up->getValue()).normalized();
     // Store down params
     if (e->type() ==  QEvent::MouseButtonPress) {
         orthogonalizeUpVector();
@@ -294,27 +295,27 @@ bool Camera3D::mouseEvent(QMouseEvent *e, int w, int h)
         targetDown = target->getValue();
         eyeDown = eye->getValue();
     } else if (e->type() ==  QEvent::MouseButtonRelease) {
-        mouseDown = QVector3D(0, 0, -1);
+        mouseDown = glm::dvec3(0, 0, -1);
     }
 
-    if (mouseDown.z() != -1 && e->buttons() != Qt::NoButton) {
-        QVector3D dp = mouseDown - pos;
+    if (mouseDown.z != -1 && e->buttons() != Qt::NoButton) {
+        glm::dvec3 dp = mouseDown - pos;
 
         double mouseSpeed = stepSize * 10.0;
-        QVector3D directionDown = (targetDown - eyeDown);
-        QVector3D rightDown = QVector3D::crossProduct(directionDown.normalized(), upDown).normalized();
+        glm::dvec3 directionDown = (targetDown - eyeDown);
+        glm::dvec3 rightDown = normalize(cross(normalize(directionDown), upDown));
 
         if (e->buttons() == Qt::RightButton) {
             if (QApplication::keyboardModifiers() == Qt::NoModifier) {
                 // Translate in screen plane
-                QVector3D offset = (-upDown * dp.y() * mouseSpeed * 2) + (rightDown * dp.x() * mouseSpeed);
+                glm::dvec3 offset = (-upDown * dp.y * mouseSpeed * 2.0) + (rightDown * dp.x * mouseSpeed);
                 eye->setValue(eyeDown + offset);
                 target->setValue(targetDown + offset);
                 return true;
             }
         } else if (e->buttons() == (Qt::RightButton | Qt::LeftButton)) {
             // Zoom
-            QVector3D newEye = eyeDown - directionDown * dp.x() * mouseSpeed;
+            glm::dvec3 newEye = eyeDown - directionDown * dp.x * mouseSpeed;
             eye->setValue(newEye);
             target->setValue(directionDown + newEye);
             return true;
@@ -322,30 +323,30 @@ bool Camera3D::mouseEvent(QMouseEvent *e, int w, int h)
 
             if (QApplication::keyboardModifiers() == Qt::ShiftModifier) {
                 // Rotate about origo
-                QMatrix4x4 mx;
-                mx.rotate(-dp.x() * mouseSpeed * 10.0, upDown);
-                QMatrix4x4 my;
-                my.rotate(-dp.y() * mouseSpeed * 10.0, rightDown);
-                QVector3D oDir = (my * mx) * (-eyeDown);
+                glm::dmat4 mx = glm::identity<glm::dmat4>();
+                mx = rotate(mx, -dp.x * mouseSpeed * 10.0, upDown);
+                glm::dmat4 my = glm::identity<glm::dmat4>();
+                my = rotate(my, -dp.y * mouseSpeed * 10.0, rightDown);
+                glm::dvec3 oDir = (my * mx) * (-eyeDown);
                 eye->setValue(-oDir);
                 target->setValue((my * mx)*directionDown - oDir);
                 up->setValue((my * mx)*upDown);
             } else if (QApplication::keyboardModifiers() == Qt::ShiftModifier + Qt::AltModifier) {
                 // Rotate around target thanks to M.Benesi
-                QMatrix4x4 mx;
-                mx.rotate(-dp.x() * mouseSpeed * 10.0, upDown);
-                QMatrix4x4 my;
-                my.rotate(-dp.y() * mouseSpeed * 10.0, rightDown);
-                QVector3D oDir = (my * mx) * (directionDown); //was -eyeDown
+                glm::dmat4 mx = glm::identity<glm::dmat4>();
+                mx = rotate(mx, -dp.x * mouseSpeed * 10.0, upDown);
+                glm::dmat4 my = glm::identity<glm::dmat4>();
+                my = rotate(my, -dp.y * mouseSpeed * 10.0, rightDown);
+                glm::dvec3 oDir = (my * mx) * (directionDown); //was -eyeDown
                 eye->setValue(targetDown - oDir);
                 // target->setValue( (my*mx)*directionDown-oDir);
                 up->setValue((my * mx)*upDown);
             } else if (QApplication::keyboardModifiers() == Qt::NoModifier) {
                 // orient camera
-                QMatrix4x4 mx;
-                mx.rotate(-dp.x() * mouseSpeed * 100.0, upDown);
-                QMatrix4x4 my;
-                my.rotate(-dp.y() * mouseSpeed * 100.0, rightDown);
+                glm::dmat4 mx = glm::identity<glm::dmat4>();
+                mx = rotate(mx, -dp.x * mouseSpeed * 100.0, upDown);
+                glm::dmat4 my = glm::identity<glm::dmat4>();
+                my = rotate(my, -dp.y * mouseSpeed * 100.0, rightDown);
                 target->setValue((my * mx) * directionDown + eye->getValue()); // before: eyeDown
                 up->setValue((my * mx)*upDown);
             }
@@ -356,7 +357,7 @@ bool Camera3D::mouseEvent(QMouseEvent *e, int w, int h)
     return false;
 }
 
-QVector3D Camera3D::transform(int width, int height)
+glm::dvec3 Camera3D::transform(int width, int height)
 {
     this->height = height;
     this->width = width;
@@ -389,9 +390,9 @@ bool Camera3D::wheelEvent(QWheelEvent *e)
             stepSize = 10.0;
         }
     } else {
-        QVector3D direction = (target->getValue() - eye->getValue());
-        QVector3D dir = direction.normalized();
-        QVector3D offset = dir * stepSize * (steps);
+        glm::dvec3 direction = (target->getValue() - eye->getValue());
+        glm::dvec3 dir = normalize(direction);
+        glm::dvec3 offset = dir * stepSize * (steps);
         eye->setValue(eye->getValue() + offset);
         target->setValue(target->getValue() + offset);
         return true;
@@ -402,40 +403,40 @@ bool Camera3D::wheelEvent(QWheelEvent *e)
 }
 
 // thanks to M Benesi and FractalForums.com :D
-QVector3D Camera3D::screenTo3D(int sx, int sy, double sz)
+glm::dvec3 Camera3D::screenTo3D(int sx, int sy, double sz)
 {
 
-    QVector3D eye2 = eye->getValue(), target2 = target->getValue(),
+    glm::dvec3 eye2 = eye->getValue(), target2 = target->getValue(),
               up2 = up->getValue();
     double coordX =
         (double(sx) / double(height) * 2.0 - double(width) / double(height));
     double coordY = (double(height - sy) / double(height) * 2.0 - 1.0);
 
-    QVector3D dir2 = (target2 - eye2).normalized();
-    QVector3D up3 = (up2 - QVector3D::dotProduct(up2, dir2) * dir2).normalized();
-    QVector3D right2 = QVector3D::crossProduct(dir2, up3).normalized();
+    glm::dvec3 dir2 = normalize(target2 - eye2);
+    glm::dvec3 up3 = normalize(up2 - dot(up2, dir2) * dir2);
+    glm::dvec3 right2 = normalize(cross(dir2, up3));
 
     dir2 = (coordX * right2 + coordY * up3) * fov->getValue() + dir2; //.4 = FOV
 
-    QVector3D ret = eye2 + dir2 / sz;
+    glm::dvec3 ret = eye2 + dir2 / sz;
 #ifndef Q_OS_WIN
-    if (std::isinf(ret.x())) {
-        ret.setX(1000.0);
+    if (std::isinf(ret.x)) {
+        ret.x=(1000.0);
     }
-    if (std::isinf(ret.y())) {
-        ret.setY(1000.0);
+    if (std::isinf(ret.y)) {
+        ret.y=(1000.0);
     }
-    if (std::isinf(ret.z())) {
-        ret.setZ(1000.0);
+    if (std::isinf(ret.z)) {
+        ret.z=(1000.0);
     }
-    if (std::isnan(ret.x())) {
-        ret.setX(0.00001);
+    if (std::isnan(ret.x)) {
+        ret.x=(0.00001);
     }
-    if (std::isnan(ret.y())) {
-        ret.setY(0.00001);
+    if (std::isnan(ret.y)) {
+        ret.y=(0.00001);
     }
-    if (std::isnan(ret.z())) {
-        ret.setZ(0.00001);
+    if (std::isnan(ret.z)) {
+        ret.z=(0.00001);
     }
 #endif
     return ret;
@@ -453,7 +454,7 @@ Camera2D::Camera2D(QStatusBar *statusBar) : statusBar(statusBar)
     center = nullptr;
     zoom = nullptr;
     zoomDown = 0.0;
-    mouseDown = QVector3D(0, 0, -1);
+    mouseDown = glm::dvec3(0, 0, -1);
     keyStatus.clear();
     stepSize = 1.0;
     width = 1;
@@ -472,7 +473,7 @@ void Camera2D::printInfo()
     INFO(QCoreApplication::translate("Camera2D","Camera: Click on 2D window for key focus. See Help Menu for more."));
 }
 
-QVector3D Camera2D::transform(int w, int h)
+glm::dvec3 Camera2D::transform(int w, int h)
 {
     width = w;
     height = h;
@@ -498,12 +499,12 @@ void Camera2D::connectWidgets(VariableEditor *ve)
 
 namespace
 {
-QVector3D getModelCoord(QVector3D mouseCoord, QVector3D center, double zoom,
+glm::dvec3 getModelCoord(glm::dvec3 mouseCoord, glm::dvec3 center, double zoom,
                         int w, int h)
 {
     double ar = h / (double)w;
-    QVector3D coord = (mouseCoord / zoom + center);
-    coord.setX(ar * coord.x());
+    glm::dvec3 coord = (mouseCoord / zoom + center);
+    coord.x=(ar * coord.x);
     return coord;
 }
 } // namespace
@@ -513,7 +514,7 @@ bool Camera2D::parseKeys()
     if (center == nullptr || zoom == nullptr) {
         return false;
     }
-    QVector3D centerValue = center->getValue();
+    glm::dvec3 centerValue = glm::dvec3(center->getValue(), 0.0);
     double zoomValue = zoom->getValue();
 
     double factor = pow(1.05f, (double)stepSize);
@@ -551,23 +552,23 @@ bool Camera2D::parseKeys()
     // ---------- Movement -----------------------------
 
     if (keyDown(Qt::Key_A)) {
-        center->setValue(centerValue + QVector3D(-zFactor, 0.0, 0.0));
+        center->setValue(centerValue + glm::dvec3(-zFactor, 0.0, 0.0));
         keysDown = true;
     }
 
     if (keyDown(Qt::Key_D)) {
-        center->setValue(centerValue + QVector3D(zFactor, 0.0, 0.0));
+        center->setValue(centerValue + glm::dvec3(zFactor, 0.0, 0.0));
         keysDown = true;
     }
 
 
     if (keyDown(Qt::Key_W)) {
-        center->setValue(centerValue + QVector3D(0.0, -zFactor, 0.0));
+        center->setValue(centerValue + glm::dvec3(0.0, -zFactor, 0.0));
         keysDown = true;
     }
 
     if (keyDown(Qt::Key_S)) {
-        center->setValue(centerValue + QVector3D(0.0, zFactor, 0.0));
+        center->setValue(centerValue + glm::dvec3(0.0, zFactor, 0.0));
         keysDown = true;
     }
 
@@ -590,8 +591,8 @@ bool Camera2D::mouseEvent(QMouseEvent *e, int w, int h)
     if (center == nullptr || zoom == nullptr) {
         return false;
     }
-    QVector3D pos = QVector3D(e->pos().x() / (0.5 * double(w)) - 1.0, 1.0 - e->pos().y() / (0.5 * double(h)), 0.0);
-    QVector3D centerValue = center->getValue();
+    glm::dvec3 pos = glm::dvec3(e->pos().x() / (0.5 * double(w)) - 1.0, 1.0 - e->pos().y() / (0.5 * double(h)), 0.0);
+    glm::dvec3 centerValue = glm::dvec3(center->getValue(), 0.0);
     double zoomValue = zoom->getValue();
 
     if (e->type() ==  QEvent::MouseButtonPress) {
@@ -599,18 +600,18 @@ bool Camera2D::mouseEvent(QMouseEvent *e, int w, int h)
         zoomDown = zoomValue;
         centerDown = centerValue;
     } else if (e->type() ==  QEvent::MouseButtonRelease) {
-        mouseDown = QVector3D(0, 0, -1);
+        mouseDown = glm::dvec3(0, 0, -1);
     }
 
     double mouseSpeed = 1.0;
-    if (mouseDown.z() != -1 && e->buttons() != Qt::NoButton) {
-        QVector3D dp = mouseDown - pos;
+    if (mouseDown.z != -1 && e->buttons() != Qt::NoButton) {
+        glm::dvec3 dp = mouseDown - pos;
         if (e->buttons() == Qt::LeftButton) {
             center->setValue(centerDown + dp * mouseSpeed / zoomDown);
         } else if (e->buttons() == Qt::RightButton) {
             // Convert mouse down to model coordinates
-            QVector3D md = getModelCoord(mouseDown, centerDown, zoomDown, w, h);
-            double newZoom = zoomDown + dp.y() * (zoomDown) * mouseSpeed;
+            glm::dvec3 md = getModelCoord(mouseDown, centerDown, zoomDown, w, h);
+            double newZoom = zoomDown + dp.y * (zoomDown) * mouseSpeed;
             double z = newZoom / zoomDown;
             center->setValue(md - (md - centerDown) / z);
             zoom->setValue(newZoom);
@@ -639,7 +640,7 @@ bool Camera2D::wheelEvent(QWheelEvent *e)
         return false;
     }
     double zoomValue = zoom->getValue();
-    QVector3D centerValue = center->getValue();
+    glm::dvec3 centerValue = glm::dvec3(center->getValue(), 0.0);
 
     double steps = e->delta() / 120.0;
     double factor = 1.15;
@@ -648,8 +649,8 @@ bool Camera2D::wheelEvent(QWheelEvent *e)
     double u = (e->pos().x() / double(width) - 0.5) * 2.0 * double(width) / double(height);
     double v = (e->pos().y() / double(height) - 0.5) * 2.0;
 
-    QVector3D pos = QVector3D(-u, v, 0.0);
-    QVector3D md = centerValue + pos / (zoomValue * g) * (1.0 - g);
+    glm::dvec3 pos = glm::dvec3(-u, v, 0.0);
+    glm::dvec3 md = centerValue + pos / (zoomValue * g) * (1.0 - g);
 
     center->setValue(md);
     zoom->setValue(zoomValue * g);

--- a/Fragmentarium-Source/Fragmentarium/GUI/CameraControl.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/CameraControl.h
@@ -5,7 +5,7 @@
 #include <QMouseEvent>
 #include <QPoint>
 #include <QStatusBar>
-#include <QVector3D>
+#include <glm/glm.hpp>
 #include <QVector>
 #include <QWheelEvent>
 
@@ -29,8 +29,8 @@ public:
 
     CameraControl();
     virtual ~CameraControl() {}
-    virtual QVector3D transform(int width, int height) = 0;
-    virtual QVector3D screenTo3D(int sx, int sy, double sz) = 0;
+    virtual glm::dvec3 transform(int width, int height) = 0;
+    virtual glm::dvec3 screenTo3D(int sx, int sy, double sz) = 0;
     virtual void printInfo() = 0;
     virtual QString getID() =0;
     virtual QVector<VariableWidget *> addWidgets ( QWidget *group,
@@ -77,8 +77,8 @@ public:
         return "3D";
     }
     virtual void printInfo();
-    virtual QVector3D screenTo3D(int sx, int sy, double sz);
-    virtual QVector3D transform(int width, int height);
+    virtual glm::dvec3 screenTo3D(int sx, int sy, double sz);
+    virtual glm::dvec3 transform(int width, int height);
     virtual void connectWidgets(VariableEditor* ve);
     virtual bool mouseEvent(QMouseEvent* e, int w, int h);
     virtual bool wheelEvent(QWheelEvent* /*e*/);
@@ -93,11 +93,11 @@ private:
     Float3Widget* target ;
     Float3Widget* up ;
     FloatWidget* fov;
-    QVector3D eyeDown ;
-    QVector3D targetDown ;
-    QVector3D upDown ;
+    glm::dvec3 eyeDown ;
+    glm::dvec3 targetDown ;
+    glm::dvec3 upDown ;
     double fovDown;
-    QVector3D mouseDown;
+    glm::dvec3 mouseDown;
 protected:
     void orthogonalizeUpVector();
         };
@@ -108,9 +108,9 @@ class Camera2D : public CameraControl
 public:
     Camera2D(QStatusBar* statusBar);
     virtual QVector<VariableWidget*> addWidgets(QWidget* group, QWidget* parent);
-    virtual QVector3D screenTo3D ( int sx, int sy, double sz )
+    virtual glm::dvec3 screenTo3D ( int sx, int sy, double sz )
     {
-        return QVector3D ( sx, sy, sz );
+        return glm::dvec3 ( sx, sy, sz );
     };
             virtual void connectWidgets(VariableEditor* ve);
     virtual QString getID()
@@ -118,7 +118,7 @@ public:
         return "2D";
     }
     virtual void printInfo();
-    virtual QVector3D transform ( int w, int h );
+    virtual glm::dvec3 transform ( int w, int h );
     virtual bool mouseEvent(QMouseEvent* e, int w, int h);
     virtual bool wheelEvent(QWheelEvent* /*e*/);
     virtual bool parseKeys();
@@ -130,9 +130,9 @@ private:
     Float2Widget* center;
     FloatWidget* zoom;
     QStatusBar* statusBar;
-    QVector3D mouseDown;
+    glm::dvec3 mouseDown;
     double zoomDown;
-    QVector3D centerDown;
+    glm::dvec3 centerDown;
 };
 } // namespace GUI
 

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -7,8 +7,9 @@
 #include <QMatrix4x4>
 #include <QMenu>
 #include <QStatusBar>
-#include <QVector2D>
-#include <QVector3D>
+#include <glm/glm.hpp>
+#include <glm/ext/matrix_transform.hpp>
+#include <glm/ext/matrix_clip_space.hpp>
 #include <QWheelEvent>
 
 #include "DisplayWidget.h"
@@ -1195,11 +1196,11 @@ void DisplayWidget::setViewPort(int w, int h)
 //   QStringList cs = mainWindow->getCameraSettings().split ( "\n" );
 //   float fov = cs.filter ( "FOV" ).at ( 0 ).split ( "=" ).at ( 1 ).toDouble();
 //   QStringList cv = cs.filter ( "Eye " ).at ( 0 ).split ( "=" ).at ( 1 ).split ( "," );
-//   QVector3D eye = QVector3D ( cv.at ( 0 ).toDouble(),cv.at ( 1 ).toDouble(),cv.at ( 2 ).toDouble() );
+//   glm::dvec3 eye = glm::dvec3 ( cv.at ( 0 ).toDouble(),cv.at ( 1 ).toDouble(),cv.at ( 2 ).toDouble() );
 //   cv = cs.filter ( "Target" ).at ( 0 ).split ( "=" ).at ( 1 ).split ( "," );
-//   QVector3D target = QVector3D ( cv.at ( 0 ).toDouble(),cv.at ( 1 ).toDouble(),cv.at ( 2 ).toDouble() );
+//   glm::dvec3 target = glm::dvec3 ( cv.at ( 0 ).toDouble(),cv.at ( 1 ).toDouble(),cv.at ( 2 ).toDouble() );
 //   cv = cs.filter ( "Up" ).at ( 0 ).split ( "=" ).at ( 1 ).split ( "," );
-//   QVector3D up = QVector3D ( cv.at ( 0 ).toDouble(),cv.at ( 1 ).toDouble(),cv.at ( 2 ).toDouble() );
+//   glm::dvec3 up = glm::dvec3 ( cv.at ( 0 ).toDouble(),cv.at ( 1 ).toDouble(),cv.at ( 2 ).toDouble() );
 //
 //   float aspectRatio = float( ( float ) width() / ( float ) height() );
 //   float zNear = 0.00001;
@@ -2080,13 +2081,14 @@ void DisplayWidget::paintGL()
         }
         if (eyeSpline != nullptr) {
             int index = mainWindow->getFrame();
-            QVector3D e = eyeSpline->getSplinePoint ( index );
-            QVector3D t = targetSpline->getSplinePoint ( index );
+            glm::dvec3 e = eyeSpline->getSplinePoint ( index );
+            glm::dvec3 t = targetSpline->getSplinePoint ( index );
             // camera path tracking makes for a bumpy ride
             //  t = eyeSpline->getSplinePoint( index+1 );
-            QVector3D u = upSpline->getSplinePoint ( index );
-            if ( !e.isNull() && !t.isNull() && !u.isNull() ) {
-                mainWindow->setCameraSettings(e, t, u.normalized()); // normalizing Up here allows spline path animating
+            glm::dvec3 u = upSpline->getSplinePoint ( index );
+            glm::dvec3 zero = glm::dvec3(0.0,0.0,0.0);
+            if ( e!=zero && t!=zero && u!=zero ) {
+                mainWindow->setCameraSettings(e, t, normalize(u)); // normalizing Up here allows spline path animating
             }
         }
     }
@@ -2224,24 +2226,24 @@ void DisplayWidget::mouseReleaseEvent(QMouseEvent *ev)
 
     // if the user just clicked and didn't drag update the statusbar
     if ( ev->pos() == mouseXY ) {
-        QVector3D mXYZ = cameraControl->screenTo3D(mouseXY.x(), mouseXY.y(), ZAtMXY);
+        glm::dvec3 mXYZ = cameraControl->screenTo3D(mouseXY.x(), mouseXY.y(), ZAtMXY);
         // update statusbar
-        mainWindow->statusBar()->showMessage(QString("X:%1 Y:%2 Z:%3").arg(mXYZ.x()).arg(mXYZ.y()).arg(mXYZ.z()));
+        mainWindow->statusBar()->showMessage(QString("X:%1 Y:%2 Z:%3").arg(mXYZ.x).arg(mXYZ.y).arg(mXYZ.z));
         if(ev->button() == Qt::MiddleButton) {
           // SpotLightDir = polar coords vec2 DE-Raytracer.frag
           // LightPos = vec3 DE-Kn2.frag
           if(ev->modifiers() == Qt::ControlModifier) {
             // placement of light in DE-Kn2.frag
                 mainWindow->setParameter(QString("LightPos = %1,%2,%3")
-                                         .arg(mXYZ.x())
-                                         .arg(mXYZ.y())
-                                         .arg(mXYZ.z()));
+                                         .arg(mXYZ.x)
+                                         .arg(mXYZ.y)
+                                         .arg(mXYZ.z));
           } else {
             // placement of target
                 mainWindow->setParameter(QString("Target = %1,%2,%3")
-                                         .arg(mXYZ.x())
-                                         .arg(mXYZ.y())
-                                         .arg(mXYZ.z()));
+                                         .arg(mXYZ.x)
+                                         .arg(mXYZ.y)
+                                         .arg(mXYZ.z));
           }
             // do we have autofocus widget
             if(getFragmentSource()->autoFocus) {
@@ -2252,16 +2254,16 @@ void DisplayWidget::mouseReleaseEvent(QMouseEvent *ev)
                         // get the eye pos
                         QStringList in = mainWindow->getParameter("Eye").split(",");
                         // convert parameter to 3d vector
-                        QVector3D e = QVector3D(in.at(0).toDouble(), in.at(1).toDouble(), in.at(2).toDouble());
+                        glm::dvec3 e = glm::dvec3(in.at(0).toDouble(), in.at(1).toDouble(), in.at(2).toDouble());
                         // calculate distance between camera and target
-                        double d = mXYZ.distanceToPoint(e);
+                        double d = distance(mXYZ, e);
                         // set the focal plane to this distance
                         mainWindow->setParameter( "FocalPlane", d );
                         mainWindow->statusBar()->showMessage(
                             QString("X:%1 Y:%2 Z:%3 Dist:%4")
-                            .arg(mXYZ.x())
-                            .arg(mXYZ.y())
-                            .arg(mXYZ.z())
+                            .arg(mXYZ.x)
+                            .arg(mXYZ.y)
+                            .arg(mXYZ.z)
                             .arg(d));
                     }
                 }
@@ -2412,12 +2414,12 @@ void DisplayWidget::updateEasingCurves(int currentframe)
 
 void DisplayWidget::drawLookatVector()
 {
-    QVector3D ec = eyeSpline->getSplinePoint ( mainWindow->getTime() +1 );
-    QVector3D tc = targetSpline->getSplinePoint ( mainWindow->getTime() +1 );
+    glm::dvec3 ec = eyeSpline->getSplinePoint ( mainWindow->getTime() +1 );
+    glm::dvec3 tc = targetSpline->getSplinePoint ( mainWindow->getTime() +1 );
     glColor4f ( 1.0,1.0,0.0,1.0 );
     glBegin ( GL_LINE_STRIP );
-    glVertex3f ( ec.x(),ec.y(),ec.z() );
-    glVertex3f ( tc.x(),tc.y(),tc.z() );
+    glVertex3f ( ec.x,ec.y,ec.z );
+    glVertex3f ( tc.x,tc.y,tc.z );
     glEnd();
 }
 
@@ -2427,27 +2429,26 @@ void DisplayWidget::setPerspective()
     QStringList cs = mainWindow->getCameraSettings().split ( "\n" );
     double fov = cs.filter ( "FOV" ).at ( 0 ).split ( "=" ).at ( 1 ).toDouble();
     QStringList cv = cs.filter ( "Eye " ).at ( 0 ).split ( "=" ).at ( 1 ).split ( "," );
-    QVector3D eye = QVector3D(cv.at(0).toDouble(), cv.at(1).toDouble(), cv.at(2).toDouble());
+    glm::dvec3 eye = glm::dvec3(cv.at(0).toDouble(), cv.at(1).toDouble(), cv.at(2).toDouble());
     cv = cs.filter ( "Target" ).at ( 0 ).split ( "=" ).at ( 1 ).split ( "," );
-    QVector3D target = QVector3D(cv.at(0).toDouble(), cv.at(1).toDouble(), cv.at(2).toDouble());
+    glm::dvec3 target = glm::dvec3(cv.at(0).toDouble(), cv.at(1).toDouble(), cv.at(2).toDouble());
     cv = cs.filter ( "Up" ).at ( 0 ).split ( "=" ).at ( 1 ).split ( "," );
-    QVector3D up = QVector3D(cv.at(0).toDouble(), cv.at(1).toDouble(), cv.at(2).toDouble());
+    glm::dvec3 up = glm::dvec3(cv.at(0).toDouble(), cv.at(1).toDouble(), cv.at(2).toDouble());
 
     auto aspectRatio = double((double)width() / (double)height());
     double zNear = 0.00001;
     double zFar = 1000.0;
     double vertAngle = 180.0 * ( 2.0 * atan2 ( 1.0, ( 1.0/fov ) ) / M_PI );
 
-    QMatrix4x4 matrix;
-    matrix.setToIdentity();
-    matrix.perspective ( vertAngle, aspectRatio, zNear, zFar );
-    matrix.lookAt ( eye,target,up );
+    glm::dmat4 matrix;
+    matrix = glm::perspective ( vertAngle, aspectRatio, zNear, zFar );
+    matrix = matrix * glm::lookAt ( eye,target,up );
 
     /// BEGIN 3DTexture
     //     texMatrix = matrix;
     /// END 3DTexture
 
-    glLoadMatrixf ( matrix.constData() );
+    glLoadMatrixd ( &matrix[0][0] );
 }
 
 QStringList DisplayWidget::getCurveSettings()
@@ -2490,9 +2491,9 @@ void DisplayWidget::drawSplines()
 void DisplayWidget::createSplines(int numberOfControlPoints, int numberOfFrames)
 {
     if( cameraID() == "3D" ) {
-        auto *eyeCp = (QVector3D *)eyeControlPoints.constData();
-        auto *tarCp = (QVector3D *)targetControlPoints.constData();
-        auto *upCp = (QVector3D *)upControlPoints.constData();
+        auto *eyeCp = (glm::dvec3 *)eyeControlPoints.constData();
+        auto *tarCp = (glm::dvec3 *)targetControlPoints.constData();
+        auto *upCp = (glm::dvec3 *)upControlPoints.constData();
 
         if (eyeCp != nullptr && tarCp != nullptr && upCp != nullptr) {
             eyeSpline = new QtSpline(this, numberOfControlPoints, numberOfFrames, eyeCp);
@@ -2508,7 +2509,7 @@ void DisplayWidget::createSplines(int numberOfControlPoints, int numberOfFrames)
     }
 }
 
-void DisplayWidget::addControlPoint(QVector3D eP, QVector3D tP, QVector3D uP)
+void DisplayWidget::addControlPoint(glm::dvec3 eP, glm::dvec3 tP, glm::dvec3 uP)
 {
     eyeControlPoints.append ( eP );
     targetControlPoints.append ( tP );

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
@@ -210,15 +210,15 @@ public:
     void drawSplines();
     void createSplines ( int numberOfControlPoints, int numberOfFrames );
 
-    void addControlPoint ( QVector3D eP, QVector3D tP, QVector3D uP );
+    void addControlPoint ( glm::dvec3 eP, glm::dvec3 tP, glm::dvec3 uP );
     void clearControlPoints();
 
     QStringList shaderAsm ( bool w );
 
     /// should make these private?
-    QVector<QVector3D> eyeControlPoints;
-    QVector<QVector3D> targetControlPoints;
-    QVector<QVector3D> upControlPoints;
+    QVector<glm::dvec3> eyeControlPoints;
+    QVector<glm::dvec3> targetControlPoints;
+    QVector<glm::dvec3> upControlPoints;
     QtSpline *eyeSpline;
     QtSpline *targetSpline;
     QtSpline *upSpline;

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
@@ -23,9 +23,7 @@
 #include <QTabWidget>
 #include <QTextBlockUserData>
 #include <QVBoxLayout>
-#include <QVector2D>
-#include <QVector3D>
-#include <QVector4D>
+#include <glm/glm.hpp>
 #include <QVector>
 #include <QWidget>
 #include <QtGui>
@@ -1459,10 +1457,11 @@ retry:
             if ( variableEditor->hasKeyFrames() ) {
                 if (engine->eyeSpline != nullptr) {
                     int index = timeStep+1;
-                    QVector3D e = engine->eyeSpline->getSplinePoint(index);
-                    QVector3D t = engine->targetSpline->getSplinePoint(index);
-                    QVector3D u = engine->upSpline->getSplinePoint(index);
-                    if( !e.isNull() && !t.isNull() && !u.isNull() ) {
+                    glm::dvec3 e = engine->eyeSpline->getSplinePoint(index);
+                    glm::dvec3 t = engine->targetSpline->getSplinePoint(index);
+                    glm::dvec3 u = engine->upSpline->getSplinePoint(index);
+                    glm::dvec3 zero = glm::dvec3(0.0,0.0,0.0);
+                    if( e!=zero && t!=zero && u!=zero ) {
                         setCameraSettings( e,t,u );
                     }
                 }
@@ -3340,19 +3339,19 @@ QString MainWindow::getCameraSettings()
     return r.join("\n");
 }
 
-void MainWindow::setCameraSettings(QVector3D e, QVector3D t, QVector3D u)
+void MainWindow::setCameraSettings(glm::dvec3 e, glm::dvec3 t, glm::dvec3 u)
 {
     DBOUT;
     QString r = QString("Eye = %1,%2,%3\nTarget = %4,%5,%6\nUp = %7,%8,%9\n")
-                .arg(e.x()).arg(e.y()).arg(e.z())
-                .arg(t.x()).arg(t.y()).arg(t.z())
-                .arg(u.x()).arg(u.y()).arg(u.z());
+                .arg(e.x).arg(e.y).arg(e.z)
+                .arg(t.x).arg(t.y).arg(t.z)
+                .arg(u.x).arg(u.y).arg(u.z);
     variableEditor->blockSignals(true);
     if(engine->getFragmentSource()->autoFocus) { // widget detected
         BoolWidget *btest = dynamic_cast<BoolWidget *>(variableEditor->getWidgetFromName("AutoFocus"));
         if (btest != nullptr) {
             if(btest->isChecked()) {
-                double d = e.distanceToPoint(t);
+                double d = distance(e, t);
                 r += QString("FocalPlane = %1\n").arg(d);
             }
     }

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
@@ -79,27 +79,27 @@ struct KeyFrameInfo {
                          .split ( "=" )
                          .at ( 1 )
                          .split ( "," );
-        eye = QVector3D ( cv.at ( 0 ).toFloat(),cv.at ( 1 ).toFloat(),cv.at ( 2 ).toFloat() );
+        eye = glm::dvec3 ( cv.at ( 0 ).toFloat(),cv.at ( 1 ).toFloat(),cv.at ( 2 ).toFloat() );
         cv = settings.filter ( "Target", Qt::CaseInsensitive )
              .at ( 0 )
              .split ( "=" )
              .at ( 1 )
              .split ( "," );
         target =
-            QVector3D ( cv.at ( 0 ).toFloat(), cv.at ( 1 ).toFloat(), cv.at ( 2 ).toFloat() );
+            glm::dvec3 ( cv.at ( 0 ).toFloat(), cv.at ( 1 ).toFloat(), cv.at ( 2 ).toFloat() );
         cv = settings.filter ( "Up", Qt::CaseInsensitive )
              .at ( 0 )
              .split ( "=" )
              .at ( 1 )
              .split ( "," );
-        up = QVector3D ( cv.at ( 0 ).toFloat(),cv.at ( 1 ).toFloat(),cv.at ( 2 ).toFloat() );
+        up = glm::dvec3 ( cv.at ( 0 ).toFloat(),cv.at ( 1 ).toFloat(),cv.at ( 2 ).toFloat() );
     }
     QString name = QString ( "" );
     QStringList rawsettings = QStringList ( "" );
     int index = 0;
-    QVector3D eye = QVector3D ( 0,0,0 );
-    QVector3D target = QVector3D ( 0,0,0 );
-    QVector3D up = QVector3D ( 0,0,0 );
+    glm::dvec3 eye = glm::dvec3 ( 0,0,0 );
+    glm::dvec3 target = glm::dvec3 ( 0,0,0 );
+    glm::dvec3 up = glm::dvec3 ( 0,0,0 );
     int first = 0;
     int last = 0;
 };
@@ -227,7 +227,7 @@ public:
     {
         return timeMaxSpinBox->value();
     }
-    void setCameraSettings ( QVector3D e, QVector3D t, QVector3D u );
+    void setCameraSettings ( glm::dvec3 e, glm::dvec3 t, glm::dvec3 u );
     int getCurrentCtrlPoint()
     {
         return variableEditor->getCurrentKeyFrame();

--- a/Fragmentarium-Source/Fragmentarium/GUI/VariableWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/VariableWidget.cpp
@@ -196,21 +196,21 @@ void FloatWidget::setUserUniform(QOpenGLShaderProgram *shaderProgram)
 
 //// ----- Float2Widget -----------------------------------------------
 
-Float2Widget::Float2Widget(QWidget *parent, QWidget *variableEditor, QString name, QVector2D defaultValue, QVector2D min, QVector2D max)
+Float2Widget::Float2Widget(QWidget *parent, QWidget *variableEditor, QString name, glm::dvec2 defaultValue, glm::dvec2 min, glm::dvec2 max)
     : VariableWidget(parent, variableEditor, name), defaultValue(defaultValue), min(min), max(max)
 {
     auto *m = new QGridLayout(widget);
     m->setSpacing(2);
     m->setContentsMargins (0,0,0,0);
 
-    comboSlider1 = new ComboSlider(parent, variableEditor, defaultValue.x(),
-                                   min.x(), max.x());
+    comboSlider1 = new ComboSlider(parent, variableEditor, defaultValue.x,
+                                   min.x, max.x);
     comboSlider1->setObjectName( QString("%1%2").arg(name).arg("1") );
     m->addWidget(comboSlider1,0,1);
     connect(comboSlider1, SIGNAL(changed()), this, SLOT(valueChanged()));
 
-    comboSlider2 = new ComboSlider(parent, variableEditor, defaultValue.y(),
-                                   min.y(), max.y());
+    comboSlider2 = new ComboSlider(parent, variableEditor, defaultValue.y,
+                                   min.y, max.y);
     comboSlider2->setObjectName( QString("%1%2").arg(name).arg("2") );
     m->addWidget(comboSlider2,1,1);
     connect(comboSlider2, SIGNAL(changed()), this, SLOT(valueChanged()));
@@ -227,17 +227,17 @@ QString Float2Widget::toString()
            .arg(QString::number(comboSlider2->getValue(),'g',p));
 }
 
-void Float2Widget::setValue(QVector3D v)
+void Float2Widget::setValue(glm::dvec2 v)
 {
-    comboSlider1->setValue(v.x());
-    comboSlider2->setValue(v.y());
+    comboSlider1->setValue(v.x);
+    comboSlider2->setValue(v.y);
 }
 
 bool Float2Widget::fromString(QString string)
 {
     double f1,f2;
     MiniParser(string).getDouble(f1).getDouble(f2);
-    QVector2D f(f1,f2);
+    glm::dvec2 f(f1,f2);
 
     if ( f == getValue() ) {
         return false;
@@ -258,15 +258,15 @@ void Float2Widget::setUserUniform(QOpenGLShaderProgram *shaderProgram)
 
 //// ----- Float3Widget -----------------------------------------------
 
-Float3Widget::Float3Widget(QWidget *parent, QWidget *variableEditor, QString name, QVector3D defaultValue, QVector3D min, QVector3D max)
+Float3Widget::Float3Widget(QWidget *parent, QWidget *variableEditor, QString name, glm::dvec3 defaultValue, glm::dvec3 min, glm::dvec3 max)
     : VariableWidget(parent, variableEditor, name), defaultValue(defaultValue), min(min), max(max)
 {
 
     normalize = false;
 
     if (min==max) {
-        min = QVector3D(-1,-1,-1);
-        max = QVector3D(1,1,1);
+        min = glm::dvec3(-1,-1,-1);
+        max = glm::dvec3(1,1,1);
         if (name != "Up") {
             normalize = true;
         } // normalizing Up at the widget level interferes with spline path animating
@@ -294,11 +294,11 @@ Float3Widget::Float3Widget(QWidget *parent, QWidget *variableEditor, QString nam
 
 }
 
-void Float3Widget::setValue(QVector3D v)
+void Float3Widget::setValue(glm::dvec3 v)
 {
-    comboSlider1->setValue(v.x());
-    comboSlider2->setValue(v.y());
-    comboSlider3->setValue(v.z());
+    comboSlider1->setValue(v.x);
+    comboSlider2->setValue(v.y);
+    comboSlider3->setValue(v.z);
 }
 
 void Float3Widget::n1Changed()
@@ -381,8 +381,8 @@ QString Float3Widget::getUniqueName()
                .arg("[0 0 0]");
     }
 
-    QString f = QString("[%1 %2 %3]").arg(min.x()).arg(min.y()).arg(min.z());
-    QString t = QString("[%1 %2 %3]").arg(max.x()).arg(max.y()).arg(max.z());
+    QString f = QString("[%1 %2 %3]").arg(min.x).arg(min.y).arg(min.z);
+    QString t = QString("[%1 %2 %3]").arg(max.x).arg(max.y).arg(max.z);
 
     return QString("%1:%2:%3:%4").arg(group).arg(getName()).arg(f).arg(t);
 }
@@ -403,7 +403,7 @@ bool Float3Widget::fromString(QString string)
 {
     double f1,f2,f3;
     MiniParser(string).getDouble(f1).getDouble(f2).getDouble(f3);
-    QVector3D f(f1,f2,f3);
+    glm::dvec3 f(f1,f2,f3);
 
     if ( f == getValue() ) {
         return false;
@@ -426,7 +426,7 @@ void Float3Widget::setUserUniform(QOpenGLShaderProgram *shaderProgram)
 
 //// ----- Float4Widget -----------------------------------------------
 
-Float4Widget::Float4Widget(QWidget *parent, QWidget *variableEditor, QString name, QVector4D defaultValue, QVector4D min, QVector4D max)
+Float4Widget::Float4Widget(QWidget *parent, QWidget *variableEditor, QString name, glm::dvec4 defaultValue, glm::dvec4 min, glm::dvec4 max)
     : VariableWidget(parent, variableEditor, name), defaultValue(defaultValue),
       min(min), max(max)
 {
@@ -439,8 +439,8 @@ Float4Widget::Float4Widget(QWidget *parent, QWidget *variableEditor, QString nam
     normalize = false;
 
     if (min==max) {
-        min = QVector4D(-1,-1,-1,-1);
-        max = QVector4D(1,1,1,1);
+        min = glm::dvec4(-1,-1,-1,-1);
+        max = glm::dvec4(1,1,1,1);
         normalize = true;
     }
 
@@ -466,26 +466,26 @@ Float4Widget::Float4Widget(QWidget *parent, QWidget *variableEditor, QString nam
 
 }
 
-void Float4Widget::setValue(QVector4D v)
+void Float4Widget::setValue(glm::dvec4 v)
 {
-    comboSlider1->setValue(v.x());
-    comboSlider2->setValue(v.y());
-    comboSlider3->setValue(v.z());
-    comboSlider4->setValue(v.w());
+    comboSlider1->setValue(v.x);
+    comboSlider2->setValue(v.y);
+    comboSlider3->setValue(v.z);
+    comboSlider4->setValue(v.w);
 }
 
 QString Float4Widget::getUniqueName()
 {
     QString f = QString("[%1 %2 %3 %4]")
-                .arg(min.x())
-                .arg(min.y())
-                .arg(min.z())
-                .arg(min.w());
+                .arg(min.x)
+                .arg(min.y)
+                .arg(min.z)
+                .arg(min.w);
     QString t = QString("[%1 %2 %3 %4]")
-                .arg(max.x())
-                .arg(max.y())
-                .arg(max.z())
-                .arg(max.w());
+                .arg(max.x)
+                .arg(max.y)
+                .arg(max.z)
+                .arg(max.w);
     return QString("%1:%2:%3:%4").arg(group).arg(getName()).arg(f).arg(t);
 }
 
@@ -506,7 +506,7 @@ bool Float4Widget::fromString(QString string)
 {
     double f1,f2,f3,f4;
     MiniParser(string).getDouble(f1).getDouble(f2).getDouble(f3).getDouble(f4);
-    QVector4D f(f1,f2,f3,f4);
+    glm::dvec4 f(f1,f2,f3,f4);
 
     if ( f == getValue() ) {
         return false;
@@ -533,7 +533,7 @@ void Float4Widget::setUserUniform(QOpenGLShaderProgram *shaderProgram)
 
 /// ------------ ColorWidget ---------------------------------------
 
-ColorWidget::ColorWidget(QWidget *parent, QWidget *variableEditor, QString name, QVector3D defaultValue)
+ColorWidget::ColorWidget(QWidget *parent, QWidget *variableEditor, QString name, glm::dvec3 defaultValue)
     : VariableWidget(parent, variableEditor, name), defaultValue(defaultValue)
 {
 
@@ -557,19 +557,19 @@ QString ColorWidget::toString()
         p = DDEC;
     }
 
-    QVector3D c = colorChooser->getValue();
+    glm::dvec3 c = colorChooser->getValue();
 
     return QString("%1,%2,%3")
-           .arg(QString::number(c.x(),'g',p))
-           .arg(QString::number(c.y(),'g',p))
-           .arg(QString::number(c.z(),'g',p));
+           .arg(QString::number(c.x,'g',p))
+           .arg(QString::number(c.y,'g',p))
+           .arg(QString::number(c.z,'g',p));
 }
 
 bool ColorWidget::fromString(QString string)
 {
     double f1,f2,f3;
     MiniParser(string).getDouble(f1).getDouble(f2).getDouble(f3);
-    QVector3D c(f1,f2,f3);
+    glm::dvec3 c(f1,f2,f3);
     if ( c == getValue() ) {
         return false;
     }
@@ -581,14 +581,14 @@ void ColorWidget::setUserUniform(QOpenGLShaderProgram *shaderProgram)
 {
     int l = uniformLocation(shaderProgram);
     if (l != -1) {
-        QVector3D c = colorChooser->getValue();
-        shaderProgram->setUniformValue(l, c.x(), c.y(), c.z());
+        glm::dvec3 c = colorChooser->getValue();
+        shaderProgram->setUniformValue(l, c.x, c.y, c.z);
     }
 }
 
 
 /// FloatColorWidget constructor.
-FloatColorWidget::FloatColorWidget(QWidget *parent, QWidget *variableEditor, QString name, double defaultValue, double min, double max, QVector3D defaultColorValue)
+FloatColorWidget::FloatColorWidget(QWidget *parent, QWidget *variableEditor, QString name, double defaultValue, double min, double max, glm::dvec3 defaultColorValue)
     : VariableWidget(parent, variableEditor, name), defaultValue(defaultValue), min(min), max(max), defaultColorValue(defaultColorValue)
 {
     auto *l = new QHBoxLayout(widget);
@@ -614,12 +614,12 @@ QString FloatColorWidget::toString()
     if (isDouble()) {
         p = DDEC;
     }
-    QVector3D c = colorChooser->getValue();
+    glm::dvec3 c = colorChooser->getValue();
     double v = comboSlider->getValue();
     return QString("%1,%2,%3,%4")
-           .arg(QString::number(c.x(),'g',p))
-           .arg(QString::number(c.y(),'g',p))
-           .arg(QString::number(c.z(),'g',p))
+           .arg(QString::number(c.x,'g',p))
+           .arg(QString::number(c.y,'g',p))
+           .arg(QString::number(c.z,'g',p))
            .arg(QString::number( v,'g',p));
 
 }
@@ -631,8 +631,8 @@ bool FloatColorWidget::fromString(QString string)
     }
     double f,f1,f2,f3;
     MiniParser(string).getDouble(f1).getDouble(f2).getDouble(f3).getDouble(f);
-    QVector3D c(f1,f2,f3);
-    if ( QVector4D(c,f) == getValue() ) {
+    glm::dvec3 c(f1,f2,f3);
+    if ( glm::dvec4(c,f) == getValue() ) {
         return false;
     }
     colorChooser->setColor(c);
@@ -645,9 +645,9 @@ void FloatColorWidget::setUserUniform(QOpenGLShaderProgram *shaderProgram)
 {
     int l = uniformLocation(shaderProgram);
     if (l != -1) {
-        QVector3D c = colorChooser->getValue();
+        glm::dvec3 c = colorChooser->getValue();
         double v = comboSlider->getValue();
-        shaderProgram->setUniformValue(l,  c.x(), c.y(), c.z(), (float)v );
+        shaderProgram->setUniformValue(l,  c.x, c.y, c.z, (float)v );
     }
 }
 

--- a/Fragmentarium-Source/Fragmentarium/GUI/VariableWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/VariableWidget.h
@@ -183,7 +183,7 @@ class ColorChooser : public QFrame
 {
     Q_OBJECT
 public:
-    ColorChooser(QWidget* parent, QVector3D defaultValue)
+    ColorChooser(QWidget* parent, glm::dvec3 defaultValue)
         : QFrame ( parent ), defaultValue ( defaultValue ), value ( defaultValue )
     {
         setLayout(new QHBoxLayout(this));
@@ -193,11 +193,11 @@ public:
     }
 
 public slots:
-    void setColor ( QVector3D v )
+    void setColor ( glm::dvec3 v )
     {
         QPalette p = palette();
         QColor c;
-        c.setRgbF(v.x(),v.y(),v.z());
+        c.setRgbF(v.x,v.y,v.z);
         p.setColor(backgroundRole(), c);
         setAutoFillBackground( true );
         setPalette(p);
@@ -207,13 +207,13 @@ public slots:
     void setColor ( QColor c )
     {
         if (c.isValid()) {
-            value = QVector3D(c.redF(), c.greenF(), c.blueF());
+            value = glm::dvec3(c.redF(), c.greenF(), c.blueF());
             setColor(value);
             emit changed();
         }
     }
 
-    QVector3D getValue()
+    glm::dvec3 getValue()
     {
         return value;
     }
@@ -222,7 +222,7 @@ private slots:
     void mouseReleaseEvent ( QMouseEvent * )
     {
         QColor initial;
-        initial.setRgbF( value.x(), value.y(), value.z() );
+        initial.setRgbF( value.x, value.y, value.z );
 
         qcd = new QColorDialog(initial);
         connect ( qcd, SIGNAL ( currentColorChanged ( QColor ) ), this, SLOT ( setColor ( QColor ) ) );
@@ -236,8 +236,8 @@ signals:
 
 private:
     QColorDialog *qcd;
-    QVector3D defaultValue;
-    QVector3D value;
+    glm::dvec3 defaultValue;
+    glm::dvec3 value;
 };
 
 
@@ -523,12 +523,12 @@ class Float2Widget : public VariableWidget
 {
 public:
     Float2Widget ( QWidget *parent, QWidget *variableEditor, QString name,
-                   QVector2D defaultValue, QVector2D min, QVector2D max );
+                   glm::dvec2 defaultValue, glm::dvec2 min, glm::dvec2 max );
 
     virtual QString getUniqueName()
     {
-        QString f = QString("[%1 %2]").arg(min.x()).arg(min.y());
-        QString t = QString("[%1 %2]").arg(max.x()).arg(max.y());
+        QString f = QString("[%1 %2]").arg(min.x).arg(min.y);
+        QString t = QString("[%1 %2]").arg(max.x).arg(max.y);
         return QString("%1:%2:%3:%4").arg(group).arg(getName()).arg(f).arg(t);
     }
 
@@ -546,11 +546,11 @@ public:
     virtual void setUserUniform(QOpenGLShaderProgram* shaderProgram);
 
     // Third component unused for these
-    QVector2D getValue()
+    glm::dvec2 getValue()
     {
-        return QVector2D ( comboSlider1->getValue(), comboSlider2->getValue() );
+        return glm::dvec2 ( comboSlider1->getValue(), comboSlider2->getValue() );
     }
-    void setValue(QVector3D v);
+    void setValue(glm::dvec2 v);
     void reset()
     {
         setValue ( defaultValue );
@@ -559,13 +559,13 @@ public:
     {
         QString type = isDouble() ? "dvec2" : "vec2";
         return "const " + type + " " + name + " = " + type + "(" +
-               toGLSL ( getValue().x() ) + "," + toGLSL ( getValue().y() ) + ");";
+               toGLSL ( getValue().x ) + "," + toGLSL ( getValue().y ) + ");";
     }
     QString getLockedSubstitution2()
     {
         QString type = isDouble() ? " dvec2(" : " vec2(";
-        return "#define " + name + type + toGLSL ( getValue().x() ) + "," +
-               toGLSL ( getValue().y() ) + ")";
+        return "#define " + name + type + toGLSL ( getValue().x ) + "," +
+               toGLSL ( getValue().y ) + ")";
     }
     void setIsDouble ( bool wd = false )
     {
@@ -578,9 +578,9 @@ private:
 
     ComboSlider* comboSlider1;
     ComboSlider* comboSlider2;
-    QVector2D defaultValue;
-    QVector2D min;
-    QVector2D max;
+    glm::dvec2 defaultValue;
+    glm::dvec2 min;
+    glm::dvec2 max;
 };
 
 
@@ -591,7 +591,7 @@ class Float3Widget : public VariableWidget
 public:
     /// FloatVariable constructor.
     Float3Widget ( QWidget *parent, QWidget *variableEditor, QString name,
-                   QVector3D defaultValue, QVector3D min, QVector3D max );
+                   glm::dvec3 defaultValue, glm::dvec3 min, glm::dvec3 max );
     virtual QString getUniqueName();
     virtual QString getValueAsText()
     {
@@ -605,12 +605,12 @@ public:
     }
     virtual QString toString();
     virtual bool fromString(QString string);
-    QVector3D getValue()
+    glm::dvec3 getValue()
     {
-        return QVector3D ( comboSlider1->getValue(), comboSlider2->getValue(),
+        return glm::dvec3 ( comboSlider1->getValue(), comboSlider2->getValue(),
                            comboSlider3->getValue() );
     }
-    void setValue(QVector3D v);
+    void setValue(glm::dvec3 v);
     virtual void setUserUniform(QOpenGLShaderProgram* shaderProgram);
     void reset()
     {
@@ -620,14 +620,14 @@ public:
     {
         QString type = isDouble() ? "dvec3" : "vec3";
         return "const " + type + " " + name + " = " + type + "(" +
-               toGLSL ( getValue().x() ) + "," + toGLSL ( getValue().y() ) + "," +
-               toGLSL ( getValue().z() ) + ");";
+               toGLSL ( getValue().x ) + "," + toGLSL ( getValue().y ) + "," +
+               toGLSL ( getValue().z ) + ");";
     }
     QString getLockedSubstitution2()
     {
         QString type = isDouble() ? " dvec3(" : " vec3(";
-        return "#define " + name + type + toGLSL ( getValue().x() ) + "," +
-               toGLSL ( getValue().y() ) + "," + toGLSL ( getValue().z() ) + ")";
+        return "#define " + name + type + toGLSL ( getValue().x ) + "," +
+               toGLSL ( getValue().y ) + "," + toGLSL ( getValue().z ) + ")";
     }
     void setIsDouble ( bool wd = false )
     {
@@ -648,9 +648,9 @@ private:
     ComboSlider* comboSlider1;
     ComboSlider* comboSlider2;
     ComboSlider* comboSlider3;
-    QVector3D defaultValue;
-    QVector3D min;
-    QVector3D max;
+    glm::dvec3 defaultValue;
+    glm::dvec3 min;
+    glm::dvec3 max;
 };
 
 /// A widget editor for a float4 variable.
@@ -660,7 +660,7 @@ class Float4Widget : public VariableWidget
 public:
     /// FloatVariable constructor.
     Float4Widget ( QWidget *parent, QWidget *variableEditor, QString name,
-                   QVector4D defaultValue, QVector4D min, QVector4D max );
+                   glm::dvec4 defaultValue, glm::dvec4 min, glm::dvec4 max );
     virtual QString getUniqueName();
     virtual QString getValueAsText()
     {
@@ -675,12 +675,12 @@ public:
     }
     virtual QString toString();
     virtual bool fromString(QString string);
-    QVector4D getValue()
+    glm::dvec4 getValue()
     {
-        return QVector4D ( comboSlider1->getValue(), comboSlider2->getValue(),
+        return glm::dvec4 ( comboSlider1->getValue(), comboSlider2->getValue(),
                            comboSlider3->getValue(), comboSlider4->getValue() );
     }
-    void setValue(QVector4D v);
+    void setValue(glm::dvec4 v);
     virtual void setUserUniform(QOpenGLShaderProgram* shaderProgram);
     void reset()
     {
@@ -690,15 +690,15 @@ public:
     {
         QString type = isDouble() ? "dvec4" : "vec4";
         return "const " + type + " " + name + " = " + type + "(" +
-               toGLSL ( getValue().x() ) + "," + toGLSL ( getValue().y() ) + "," +
-               toGLSL ( getValue().z() ) + "," + toGLSL ( getValue().w() ) + ");";
+               toGLSL ( getValue().x ) + "," + toGLSL ( getValue().y ) + "," +
+               toGLSL ( getValue().z ) + "," + toGLSL ( getValue().w ) + ");";
     }
     QString getLockedSubstitution2()
     {
         QString type = isDouble() ? " dvec4(" : " vec4(";
-        return "#define " + name + type + toGLSL ( getValue().x() ) + "," +
-               toGLSL ( getValue().y() ) + "," + toGLSL ( getValue().z() ) + "," +
-               toGLSL ( getValue().w() ) + ")";
+        return "#define " + name + type + toGLSL ( getValue().x ) + "," +
+               toGLSL ( getValue().y ) + "," + toGLSL ( getValue().z ) + "," +
+               toGLSL ( getValue().w ) + ")";
     }
     void setIsDouble ( bool wd = false )
     {
@@ -717,9 +717,9 @@ private:
     ComboSlider* comboSlider2;
     ComboSlider* comboSlider3;
     ComboSlider* comboSlider4;
-    QVector4D defaultValue;
-    QVector4D min;
-    QVector4D max;
+    glm::dvec4 defaultValue;
+    glm::dvec4 min;
+    glm::dvec4 max;
 };
 
 class ColorWidget : public VariableWidget
@@ -727,28 +727,28 @@ class ColorWidget : public VariableWidget
 public:
     /// FloatVariable constructor.
     ColorWidget ( QWidget *parent, QWidget *variableEditor, QString name,
-                  QVector3D defaultValue );
+                  glm::dvec3 defaultValue );
     virtual QString getUniqueName()
     {
         return QString ( "%1:%2" ).arg ( group ).arg ( getName() );
     }
     virtual QString getValueAsText()
     {
-        QVector3D t = colorChooser->getValue();
+        glm::dvec3 t = colorChooser->getValue();
         int p = FDEC;
         if ( isDouble() ) {
             p = DDEC;
         }
-        return QString::number ( t.x(), 'g', p ) + "," +
-               QString::number ( t.y(), 'g', p ) + "," +
-               QString::number ( t.z(), 'g', p );
+        return QString::number ( t.x, 'g', p ) + "," +
+               QString::number ( t.y, 'g', p ) + "," +
+               QString::number ( t.z, 'g', p );
     }
 
-    QVector3D getValue()
+    glm::dvec3 getValue()
     {
         return colorChooser->getValue();
     }
-    void setValue(QVector3D v);
+    void setValue(glm::dvec3 v);
     virtual QString toString();
     virtual bool fromString(QString string);
     virtual void setUserUniform(QOpenGLShaderProgram* shaderProgram);
@@ -760,16 +760,16 @@ public:
     {
         QString type = isDouble() ? "dvec3" : "vec3";
         return "const " + type + " " + name + " = " + type + "(" +
-               toGLSL ( colorChooser->getValue().x() ) + "," +
-               toGLSL ( colorChooser->getValue().y() ) + "," +
-               toGLSL ( colorChooser->getValue().z() ) + ");";
+               toGLSL ( colorChooser->getValue().x ) + "," +
+               toGLSL ( colorChooser->getValue().y ) + "," +
+               toGLSL ( colorChooser->getValue().z ) + ");";
     }
     QString getLockedSubstitution2()
     {
         QString type = isDouble() ? " dvec3(" : " vec3(";
-        return "#define " + name + type + toGLSL ( colorChooser->getValue().x() ) +
-               "," + toGLSL ( colorChooser->getValue().y() ) + "," +
-               toGLSL ( colorChooser->getValue().z() ) + ")";
+        return "#define " + name + type + toGLSL ( colorChooser->getValue().x ) +
+               "," + toGLSL ( colorChooser->getValue().y ) + "," +
+               toGLSL ( colorChooser->getValue().z ) + ")";
     }
     void setIsDouble ( bool wd = false )
     {
@@ -777,7 +777,7 @@ public:
     };
 private:
     ColorChooser* colorChooser;
-    QVector3D defaultValue;
+    glm::dvec3 defaultValue;
 };
 
 class FloatColorWidget : public VariableWidget
@@ -786,28 +786,28 @@ public:
     /// FloatVariable constructor.
     FloatColorWidget ( QWidget *parent, QWidget *variableEditor, QString name,
                        double defaultValue, double min, double max,
-                       QVector3D defaultColorValue );
+                       glm::dvec3 defaultColorValue );
     virtual QString getUniqueName()
     {
         return QString ( "%1:%2:%3:%4" ).arg ( group ).arg ( getName() ).arg ( min ).arg ( max );
     }
     virtual QString getValueAsText()
     {
-        QVector3D t = colorChooser->getValue();
+        glm::dvec3 t = colorChooser->getValue();
         int p = FDEC;
         if ( isDouble() ) {
             p = DDEC;
         }
-        return QString::number ( t.x(), 'g', p ) + "," +
-               QString::number ( t.y(), 'g', p ) + "," +
-               QString::number ( t.z(), 'g', p ) + "," +
+        return QString::number ( t.x, 'g', p ) + "," +
+               QString::number ( t.y, 'g', p ) + "," +
+               QString::number ( t.z, 'g', p ) + "," +
                QString::number ( comboSlider->getValue(), 'g', p );
     }
-    QVector4D getValue()
+    glm::dvec4 getValue()
     {
-        return QVector4D ( colorChooser->getValue(), comboSlider->getValue() );
+        return glm::dvec4 ( colorChooser->getValue(), comboSlider->getValue() );
     }
-    void setValue(QVector4D v);
+    void setValue(glm::dvec4 v);
     virtual QString toString();
     virtual bool fromString(QString string);
     virtual void setUserUniform(QOpenGLShaderProgram* shaderProgram);
@@ -820,17 +820,17 @@ public:
     {
         QString type = isDouble() ? "dvec4" : "vec4";
         return "const " + type + " " + name + " = " + type + "(" +
-               toGLSL ( colorChooser->getValue().x() ) + "," +
-               toGLSL ( colorChooser->getValue().y() ) + "," +
-               toGLSL ( colorChooser->getValue().z() ) + "," +
+               toGLSL ( colorChooser->getValue().x ) + "," +
+               toGLSL ( colorChooser->getValue().y ) + "," +
+               toGLSL ( colorChooser->getValue().z ) + "," +
                toGLSL ( comboSlider->getValue() ) + ");";
     }
     QString getLockedSubstitution2()
     {
         QString type = isDouble() ? " dvec4(" : " vec4(";
-        return "#define " + name + type + toGLSL ( colorChooser->getValue().x() ) +
-               "," + toGLSL ( colorChooser->getValue().y() ) + "," +
-               toGLSL ( colorChooser->getValue().z() ) + "," +
+        return "#define " + name + type + toGLSL ( colorChooser->getValue().x ) +
+               "," + toGLSL ( colorChooser->getValue().y ) + "," +
+               toGLSL ( colorChooser->getValue().z ) + "," +
                toGLSL ( comboSlider->getValue() ) + ")";
     }
     void setIsDouble ( bool wd = false )
@@ -844,7 +844,7 @@ private:
     double defaultValue;
     double min;
     double max;
-    QVector3D defaultColorValue;
+    glm::dvec3 defaultColorValue;
 };
 
 class IntWidget : public VariableWidget

--- a/Fragmentarium-Source/Fragmentarium/Parser/Preprocessor.cpp
+++ b/Fragmentarium-Source/Fragmentarium/Parser/Preprocessor.cpp
@@ -5,8 +5,7 @@
 #include <QDir>
 #include <QCoreApplication>
 #include <QVector>
-#include <QVector3D>
-#include <QVector4D>
+#include <glm/glm.hpp>
 #include "../../SyntopiaCore/Exceptions/Exception.h"
 #include "../../SyntopiaCore/Logging/Logging.h"
 #include "Preprocessor.h"
@@ -73,17 +72,17 @@ void setLockType(GuiParameter *p, QString lockTypeString)
     p->setLockType(l);
 }
 
-QVector4D parseQVector4D(QString s1, QString s2, QString s3, QString s4)
+glm::dvec4 parseQVector4D(QString s1, QString s2, QString s3, QString s4)
 {
     return { parseFloat(s1), parseFloat(s2), parseFloat(s3), parseFloat(s4) };
 }
 
-QVector3D parseQVector3D(QString s1, QString s2, QString s3)
+glm::dvec3 parseQVector3D(QString s1, QString s2, QString s3)
 {
     return { parseFloat(s1), parseFloat(s2), parseFloat(s3) };
 }
 
-QVector2D parseQVector2D(QString s1, QString s2)
+glm::dvec2 parseQVector2D(QString s1, QString s2)
 {
     return { parseFloat(s1), parseFloat(s2) };
 }
@@ -346,7 +345,7 @@ void Preprocessor::parseFloatColorChooser(FragmentSource *fs, int i)
     QString fromS = floatColorChooser.cap(3);
     QString defS = floatColorChooser.cap(4);
     QString toS = floatColorChooser.cap(5);
-    QVector3D defaults = parseQVector3D(floatColorChooser.cap(6), floatColorChooser.cap(7), floatColorChooser.cap(8));
+    glm::dvec3 defaults = parseQVector3D(floatColorChooser.cap(6), floatColorChooser.cap(7), floatColorChooser.cap(8));
 
     bool succes = false;
     double from = fromS.toDouble(&succes);
@@ -396,9 +395,9 @@ void Preprocessor::parseFloat2Slider(FragmentSource *fs, int i)
     QString type = float2Slider.cap(1);
     QString name = float2Slider.cap(2);
     fs->source[i] = "uniform " + type + " " + name + ";"; // uniform location
-    QVector2D from = parseQVector2D(float2Slider.cap(3), float2Slider.cap(4));
-    QVector2D defaults = parseQVector2D(float2Slider.cap(5), float2Slider.cap(6));
-    QVector2D to = parseQVector2D(float2Slider.cap(7), float2Slider.cap(8));
+    glm::dvec2 from = parseQVector2D(float2Slider.cap(3), float2Slider.cap(4));
+    glm::dvec2 defaults = parseQVector2D(float2Slider.cap(5), float2Slider.cap(6));
+    glm::dvec2 to = parseQVector2D(float2Slider.cap(7), float2Slider.cap(8));
 
     Float2Parameter *fp = new Float2Parameter(currentGroup, name, lastComment, from, to, defaults);
     setLockType(fp, float2Slider.cap(9));
@@ -411,9 +410,9 @@ void Preprocessor::parseFloat3Slider(FragmentSource *fs, int i)
     QString type = float3Slider.cap(1);
     QString name = float3Slider.cap(2);
     fs->source[i] = "uniform " + type + " " + name + ";"; // uniform location
-    QVector3D from = parseQVector3D(float3Slider.cap(3), float3Slider.cap(4), float3Slider.cap(5));
-    QVector3D defaults = parseQVector3D(float3Slider.cap(6), float3Slider.cap(7), float3Slider.cap(8));
-    QVector3D to = parseQVector3D(float3Slider.cap(9), float3Slider.cap(10), float3Slider.cap(11));
+    glm::dvec3 from = parseQVector3D(float3Slider.cap(3), float3Slider.cap(4), float3Slider.cap(5));
+    glm::dvec3 defaults = parseQVector3D(float3Slider.cap(6), float3Slider.cap(7), float3Slider.cap(8));
+    glm::dvec3 to = parseQVector3D(float3Slider.cap(9), float3Slider.cap(10), float3Slider.cap(11));
 
     Float3Parameter *fp = new Float3Parameter(currentGroup, name, lastComment, from, to, defaults);
     setLockType(fp, float3Slider.cap(12));
@@ -426,9 +425,9 @@ void Preprocessor::parseFloat4Slider(FragmentSource *fs, int i)
     QString type = float4Slider.cap(1);
     QString name = float4Slider.cap(2);
     fs->source[i] = "uniform " + type + " " + name + ";"; // uniform location
-    QVector4D from = parseQVector4D(float4Slider.cap(3), float4Slider.cap(4), float4Slider.cap(5), float4Slider.cap(6));
-    QVector4D defaults = parseQVector4D(float4Slider.cap(7), float4Slider.cap(8), float4Slider.cap(9), float4Slider.cap(10));
-    QVector4D to = parseQVector4D(float4Slider.cap(11), float4Slider.cap(12), float4Slider.cap(13), float4Slider.cap(14));
+    glm::dvec4 from = parseQVector4D(float4Slider.cap(3), float4Slider.cap(4), float4Slider.cap(5), float4Slider.cap(6));
+    glm::dvec4 defaults = parseQVector4D(float4Slider.cap(7), float4Slider.cap(8), float4Slider.cap(9), float4Slider.cap(10));
+    glm::dvec4 to = parseQVector4D(float4Slider.cap(11), float4Slider.cap(12), float4Slider.cap(13), float4Slider.cap(14));
 
     Float4Parameter *fp = new Float4Parameter(currentGroup, name, lastComment, from, to, defaults);
     setLockType(fp, float4Slider.cap(15));
@@ -441,7 +440,7 @@ void Preprocessor::parseColorChooser(FragmentSource *fs, int i)
     QString type = colorChooser.cap(1);
     QString name = colorChooser.cap(2);
     fs->source[i] = "uniform " + type + " " + name + ";";
-    QVector3D defaults = parseQVector3D(colorChooser.cap(3), colorChooser.cap(4), colorChooser.cap(5));
+    glm::dvec3 defaults = parseQVector3D(colorChooser.cap(3), colorChooser.cap(4), colorChooser.cap(5));
     ColorParameter *cp = new ColorParameter(currentGroup, name, lastComment, defaults);
     setLockType(cp, colorChooser.cap(6));
     if (type.startsWith("d")) cp->setIsDouble(true);

--- a/Fragmentarium-Source/Fragmentarium/Parser/Preprocessor.h
+++ b/Fragmentarium-Source/Fragmentarium/Parser/Preprocessor.h
@@ -6,9 +6,7 @@
 #include <QList>
 #include <QFile>
 #include <QVector>
-#include <QVector2D>
-#include <QVector3D>
-#include <QVector4D>
+#include <glm/glm.hpp>
 #include <QMap>
 
 #include "../GUI/FileManager.h"
@@ -156,104 +154,104 @@ private:
 
 class Float2Parameter : public GuiParameter {
 public:
-    Float2Parameter(QString group, QString name,QString tooltip,  QVector2D from, QVector2D to, QVector2D defaultValue) :
+    Float2Parameter(QString group, QString name,QString tooltip,  glm::dvec2 from, glm::dvec2 to, glm::dvec2 defaultValue) :
         GuiParameter(group, name, tooltip), from(from), to(to), defaultValue(defaultValue) {}
 
     virtual QString getUniqueName() {
-        QString f = QString("[%1 %2]").arg(from.x()).arg(from.y());
-        QString t = QString("[%1 %2]").arg(to.x()).arg(to.y());
+        QString f = QString("[%1 %2]").arg(from.x).arg(from.y);
+        QString t = QString("[%1 %2]").arg(to.x).arg(to.y);
         return QString("%1:%2:%3:%4").arg(group).arg(getName()).arg(f).arg(t);
     }
-    QVector2D getFrom() {
+    glm::dvec2 getFrom() {
         return from;
     }
-    QVector2D getTo() {
+    glm::dvec2 getTo() {
         return to;
     }
-    QVector2D getDefaultValue() {
+    glm::dvec2 getDefaultValue() {
         return defaultValue;
     }
 private:
-    QVector2D from;
-    QVector2D to;
-    QVector2D defaultValue;
+    glm::dvec2 from;
+    glm::dvec2 to;
+    glm::dvec2 defaultValue;
 };
 
 class Float3Parameter : public GuiParameter {
 public:
-    Float3Parameter(QString group, QString name,QString tooltip,  QVector3D from, QVector3D to, QVector3D defaultValue) :
+    Float3Parameter(QString group, QString name,QString tooltip,  glm::dvec3 from, glm::dvec3 to, glm::dvec3 defaultValue) :
         GuiParameter(group, name, tooltip), from(from), to(to), defaultValue(defaultValue) {}
 
     virtual QString getUniqueName() {
-        QString f = QString("[%1 %2 %3]").arg(from.x()).arg(from.y()).arg(from.z());
-        QString t = QString("[%1 %2 %3]").arg(to.x()).arg(to.y()).arg(to.z());
+        QString f = QString("[%1 %2 %3]").arg(from.x).arg(from.y).arg(from.z);
+        QString t = QString("[%1 %2 %3]").arg(to.x).arg(to.y).arg(to.z);
         return QString("%1:%2:%3:%4").arg(group).arg(getName()).arg(f).arg(t);
     }
-    QVector3D getFrom() {
+    glm::dvec3 getFrom() {
         return from;
     }
-    QVector3D getTo() {
+    glm::dvec3 getTo() {
         return to;
     }
-    QVector3D getDefaultValue() {
+    glm::dvec3 getDefaultValue() {
         return defaultValue;
     }
 private:
-    QVector3D from;
-    QVector3D to;
-    QVector3D defaultValue;
+    glm::dvec3 from;
+    glm::dvec3 to;
+    glm::dvec3 defaultValue;
 };
 
 class Float4Parameter : public GuiParameter {
 public:
-    Float4Parameter(QString group, QString name,QString tooltip,  QVector4D from, QVector4D to, QVector4D defaultValue) :
+    Float4Parameter(QString group, QString name,QString tooltip,  glm::dvec4 from, glm::dvec4 to, glm::dvec4 defaultValue) :
         GuiParameter(group, name, tooltip), from(from), to(to), defaultValue(defaultValue) {}
 
     virtual QString getUniqueName() {
-        QString f = QString("[%1 %2 %3 %4]").arg(from.x()).arg(from.y()).arg(from.z()).arg(from.w());
-        QString t = QString("[%1 %2 %3 %4]").arg(to.x()).arg(to.y()).arg(to.z()).arg(to.w());
+        QString f = QString("[%1 %2 %3 %4]").arg(from.x).arg(from.y).arg(from.z).arg(from.w);
+        QString t = QString("[%1 %2 %3 %4]").arg(to.x).arg(to.y).arg(to.z).arg(to.w);
         return QString("%1:%2:%3:%4").arg(group).arg(getName()).arg(f).arg(t);
     }
-    QVector4D getFrom() {
+    glm::dvec4 getFrom() {
         return from;
     }
-    QVector4D getTo() {
+    glm::dvec4 getTo() {
         return to;
     }
-    QVector4D getDefaultValue() {
+    glm::dvec4 getDefaultValue() {
         return defaultValue;
     }
 private:
-    QVector4D from;
-    QVector4D to;
-    QVector4D defaultValue;
+    glm::dvec4 from;
+    glm::dvec4 to;
+    glm::dvec4 defaultValue;
 };
 
 class ColorParameter : public GuiParameter {
 public:
-    ColorParameter(QString group, QString name,QString tooltip, QVector3D defaultValue) :
+    ColorParameter(QString group, QString name,QString tooltip, glm::dvec3 defaultValue) :
         GuiParameter(group,name, tooltip), defaultValue(defaultValue) {}
 
     virtual QString getUniqueName() {
         return QString("%1:%2").arg(group).arg(getName());
     }
-    QVector3D getDefaultValue() {
+    glm::dvec3 getDefaultValue() {
         return defaultValue;
     }
 private:
-    QVector3D defaultValue;
+    glm::dvec3 defaultValue;
 };
 
 
 class FloatColorParameter : public GuiParameter {
 public:
-    FloatColorParameter(QString group, QString name,QString tooltip, float defaultValue, float from, float to, QVector3D defaultColorValue) :
+    FloatColorParameter(QString group, QString name,QString tooltip, float defaultValue, float from, float to, glm::dvec3 defaultColorValue) :
         GuiParameter(group,name, tooltip), defaultValue(defaultValue), from(from), to(to), defaultColorValue(defaultColorValue) {}
 
     virtual QString getUniqueName() {
         return QString("%1:%2:%3:%4").arg(group).arg(getName()).arg(from).arg(to);
     }
-    QVector3D getDefaultColorValue() {
+    glm::dvec3 getDefaultColorValue() {
         return defaultColorValue;
     }
     double getFrom() {
@@ -269,7 +267,7 @@ private:
     double defaultValue;
     double from;
     double to;
-    QVector3D defaultColorValue;
+    glm::dvec3 defaultColorValue;
 };
 
 class BoolParameter : public GuiParameter {

--- a/Fragmentarium-Source/ThirdPartyCode/QtSpline.cpp
+++ b/Fragmentarium-Source/ThirdPartyCode/QtSpline.cpp
@@ -39,7 +39,7 @@
 ****************************************************************************/
 
 #include <QOpenGLWidget>
-#include <QVector3D>
+#include <glm/glm.hpp>
 
 #include <qmath.h>
 
@@ -63,7 +63,7 @@ void Geometry::loadArrays() const
     glVertexPointer(3, GL_FLOAT, 0, vertices.constData());
 }
 
-void Geometry::appendVertex(const QVector3D &a)
+void Geometry::appendVertex(const glm::dvec3 &a)
 {
     vertices.append(a);
 }
@@ -80,7 +80,7 @@ void Patch::draw(int n, int p) const
     glDepthMask(GL_TRUE); // Write to depth buffer for control points
     glPointSize(pointSize);
     if (start == 0) { /// drawing control points
-        const QVector3D *v = geom->vertices.constData();
+        const glm::dvec3 *v = geom->vertices.constData();
         for (uint i = 0; i < count; i++) {
             int objIndex = i + (n * count);
             if (p == objIndex) {
@@ -89,7 +89,7 @@ void Patch::draw(int n, int p) const
                 glColor4fv(color);
             }
             glBegin(GL_POINTS);
-            glVertex3f(v[i].x(), v[i].y(), v[i].z());
+            glVertex3f(v[i].x, v[i].y, v[i].z);
             glEnd();
         }
         glDepthMask(GL_FALSE); // no Write to depth buffer for spline points
@@ -104,7 +104,7 @@ void Patch::draw(int n, int p) const
     }
 }
 
-void Patch::addVertex(const QVector3D &a)
+void Patch::addVertex(const glm::dvec3 &a)
 {
     geom->appendVertex(a);
     count++;
@@ -121,10 +121,10 @@ public:
 class VectControlPoints : public Vectoid
 {
 public:
-    VectControlPoints(Geometry *g, int num_ctrlpoints, QVector3D *ctrlpoints);
+    VectControlPoints(Geometry *g, int num_ctrlpoints, glm::dvec3 *ctrlpoints);
 };
 
-VectControlPoints::VectControlPoints(Geometry *g, int num_ctrlpoints, QVector3D *ctrlpoints)
+VectControlPoints::VectControlPoints(Geometry *g, int num_ctrlpoints, glm::dvec3 *ctrlpoints)
 {
     auto *cp = new Patch(g);
     // control points
@@ -145,7 +145,7 @@ public:
 
     // modified from
     // http://www.iquilezles.org/www/articles/minispline/minispline.htm
-    void spline(const QVector3D *cP, int num, double t, QVector3D *v)
+    void spline(const glm::dvec3 *cP, int num, double t, glm::dvec3 *v)
     {
         static double coefs[4][4] = {{-1.0, 2.0, -1.0, 0.0},
             {3.0, -5.0, 0.0, 2.0},
@@ -172,9 +172,9 @@ public:
                 kn = num - 1;
             }
             double b = 0.5f * (((coefs[i][0] * h + coefs[i][1]) * h + coefs[i][2]) * h + coefs[i][3]);
-            v->setX(v->x() + (b * cP[kn].x()));
-            v->setY(v->y() + (b * cP[kn].y()));
-            v->setZ(v->z() + (b * cP[kn].z()));
+            v->x=(v->x + (b * cP[kn].x));
+            v->y=(v->y + (b * cP[kn].y));
+            v->z=(v->z + (b * cP[kn].z));
         }
     }
 };
@@ -188,7 +188,7 @@ VectSpline::VectSpline(Geometry *g, int num_ctrlpoints, int num_segments)
     double enD =
         (1.0 / ((num_segments - 1.0) + ((num_segments - 1.0) * (1.0 / (num_ctrlpoints - 1.0)))));
     for (int i = 0; i < num_segments; i++) {
-        QVector3D s(0.0, 0.0, 0.0);
+        glm::dvec3 s(0.0, 0.0, 0.0);
         spline(g->vertices.constData(), num_ctrlpoints, enD * i, &s);
         sp->addVertex(s);
     }
@@ -199,7 +199,7 @@ VectSpline::VectSpline(Geometry *g, int num_ctrlpoints, int num_segments)
 }
 
 // TODO add start frame end frame for control points
-QtSpline::QtSpline(QOpenGLWidget *parent, int nctrl, int nsegs, QVector3D *cv)
+QtSpline::QtSpline(QOpenGLWidget *parent, int nctrl, int nsegs, glm::dvec3 *cv)
     : prnt(parent), geom(new Geometry())
 {
     buildGeometry(nctrl, nsegs, cv);
@@ -211,7 +211,7 @@ QtSpline::~QtSpline()
     delete geom;
 }
 
-void QtSpline::buildGeometry(int nctrl, int nsegs, QVector3D *cv)
+void QtSpline::buildGeometry(int nctrl, int nsegs, glm::dvec3 *cv)
 {
     VectControlPoints ctrl(geom, nctrl, cv);
     parts << ctrl.parts;
@@ -245,36 +245,36 @@ void QtSpline::setSplineColor(QColor c) const
     qSetColor(parts[1]->color, c);
 }
 
-QVector3D QtSpline::getControlPoint(int n)
+glm::dvec3 QtSpline::getControlPoint(int n)
 {
     return geom->vertices[n];
 }
 
-QVector3D QtSpline::getSplinePoint(int n)
+glm::dvec3 QtSpline::getSplinePoint(int n)
 {
     return geom->vertices[n + num_c - 1];
 }
 
-void QtSpline::setControlPoint(int n, QVector3D *p)
+void QtSpline::setControlPoint(int n, glm::dvec3 *p)
 {
 
     /// new control point position
-    geom->vertices[n].setX(p->x());
-    geom->vertices[n].setY(p->y());
-    geom->vertices[n].setZ(p->z());
+    geom->vertices[n].x=(p->x);
+    geom->vertices[n].y=(p->y);
+    geom->vertices[n].z=(p->z);
     /// this bit of fudge lets the end points land on their respective
     /// controlpoints
     double enD = (1.0 / ((num_s - 1.0) + ((num_s - 1.0) * (1.0 / (parts[0]->count - 1.0)))));
     /// new spline curve
     for (int i = 0; i < num_s; i++) {
-        QVector3D s(0.0, 0.0, 0.0);
+        glm::dvec3 s(0.0, 0.0, 0.0);
         ((VectSpline *)parts[1])
         ->spline(geom->vertices.constData(), num_c, enD * i, &s);
         geom->vertices[i + num_c] = s;
     }
 }
 
-void QtSpline::recalc(int nc, int ns, QVector3D *cv)
+void QtSpline::recalc(int nc, int ns, glm::dvec3 *cv)
 {
     parts.clear();
     buildGeometry(nc, ns, cv);

--- a/Fragmentarium-Source/ThirdPartyCode/QtSpline.h
+++ b/Fragmentarium-Source/ThirdPartyCode/QtSpline.h
@@ -42,7 +42,7 @@
 #define QTSPLINE_H
 #include <QColor>
 #include <QObject>
-#include <QVector3D>
+#include <glm/glm.hpp>
 #include <QtOpenGL>
 
 #include <QDebug>
@@ -53,8 +53,8 @@ namespace GUI
 {
 
 struct Geometry {
-    QVector<QVector3D> vertices;
-    void appendVertex ( const QVector3D &a );
+    QVector<glm::dvec3> vertices;
+    void appendVertex ( const glm::dvec3 &a );
     void loadArrays() const;
 };
 
@@ -63,7 +63,7 @@ class Patch
 public:
     Patch ( Geometry * );
     void draw ( int n = 0, int p = 0 ) const;
-    void addVertex ( const QVector3D &a );
+    void addVertex ( const glm::dvec3 &a );
     GLuint start;
     GLuint count;
     GLfloat pointSize;
@@ -74,7 +74,7 @@ public:
 class QtSpline : public QObject
 {
 public:
-    QtSpline ( QOpenGLWidget *parent, int nctrl = 0, int nsegs = 0, QVector3D *cv = 0 );
+    QtSpline ( QOpenGLWidget *parent, int nctrl = 0, int nsegs = 0, glm::dvec3 *cv = 0 );
     ~QtSpline();
 
     void setSplineColor ( QColor c ) const;
@@ -82,13 +82,13 @@ public:
     void drawControlPoints ( int n = 0 ) const;
     void drawSplinePoints() const;
 
-    QVector3D getControlPoint ( int n );
-    QVector3D getSplinePoint ( int n );
-    void setControlPoint ( int n, QVector3D *p );
-    void recalc ( int nc, int ns, QVector3D *cv );
+    glm::dvec3 getControlPoint ( int n );
+    glm::dvec3 getSplinePoint ( int n );
+    void setControlPoint ( int n, glm::dvec3 *p );
+    void recalc ( int nc, int ns, glm::dvec3 *cv );
 
 private:
-    void buildGeometry ( int nctrl, int nsegs, QVector3D *cv );
+    void buildGeometry ( int nctrl, int nsegs, glm::dvec3 *cv );
     QOpenGLWidget *prnt;
     Geometry *geom;
     QList<Patch *> parts;

--- a/Fragmentarium-Source/ThirdPartyCode/TimeLine.cpp
+++ b/Fragmentarium-Source/ThirdPartyCode/TimeLine.cpp
@@ -460,23 +460,23 @@ void TimeLineDialog::mousePressEvent(QMouseEvent *ev)
                         kfr = keyframeMap.count() - 1;
                     }
                     // get values from our keframe map
-                    QVector3D e = keyframeMap.value(kfr)->eye;
-                    QVector3D t = keyframeMap.value(kfr)->target;
-                    QVector3D u = keyframeMap.value(kfr)->up;
+                    glm::dvec3 e = keyframeMap.value(kfr)->eye;
+                    glm::dvec3 t = keyframeMap.value(kfr)->target;
+                    glm::dvec3 u = keyframeMap.value(kfr)->up;
                     // put them in a stext string for display
                     QString dlist = QString("");
                     dlist += QString("EYE:\t X %1 Y %2 Z %3 \n")
-                             .arg(e.x())
-                             .arg(e.y())
-                             .arg(e.z());
+                             .arg(e.x)
+                             .arg(e.y)
+                             .arg(e.z);
                     dlist += QString("TARGET:\t X %1 Y %2 Z %3 \n")
-                             .arg(t.x())
-                             .arg(t.y())
-                             .arg(t.z());
+                             .arg(t.x)
+                             .arg(t.y)
+                             .arg(t.z);
                     dlist += QString("UP:\t X %1 Y %2 Z %3 \n")
-                             .arg(u.x())
-                             .arg(u.y())
-                             .arg(u.z());
+                             .arg(u.x)
+                             .arg(u.y)
+                             .arg(u.z);
                     // fudge for last frame ?
                     if (kf.key() + 1 > frames) {
                         dlist += QString("\nLast Frame %1").arg(frames);


### PR DESCRIPTION
Switch from `QVector3D` etc to `glm::dvec3` etc.  Fixes the quantization problems with the 2D camera at deep zooms with double precision.  3D camera still works (tested briefly).

So far untested: splines, timeline, colour widget.

Still missing: cmake configure-time check for glm.