### PR TITLE
logarithmic slider support

### DIFF
--- a/Fragmentarium-Source/Examples/Experimental/LogSliderTest.frag
+++ b/Fragmentarium-Source/Examples/Experimental/LogSliderTest.frag
@@ -1,0 +1,11 @@
+#include "MathUtils.frag"
+#include "Progressive2D.frag"
+
+uniform float Good; slider[1e-3,1,1e3] Logarithmic
+uniform float Bad; slider[-1,0,1] Logarithmic
+uniform float Ugly; slider[-1e3,-1,-1e-3] Logarithmic
+
+vec3 color(vec2 p)
+{
+  return vec3(Good / 1000.0, Bad / 2.0 + 0.5, Ugly / -1000.0);
+}

--- a/Fragmentarium-Source/Fragmentarium/GUI/VariableEditor.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/VariableEditor.cpp
@@ -440,7 +440,7 @@ void VariableEditor::createWidgetFromGuiParameter(Parser::GuiParameter* p) {
     if (dynamic_cast<Parser::FloatParameter *>(p) != nullptr) {
         auto *fp = dynamic_cast<Parser::FloatParameter *>(p);
         QString name = fp->getName();
-        FloatWidget *fw = new FloatWidget(currentWidget, this, name, fp->getDefaultValue(), fp->getFrom(), fp->getTo());
+        FloatWidget *fw = new FloatWidget(currentWidget, this, name, fp->getDefaultValue(), fp->getFrom(), fp->getTo(), fp->getSliderType() == Logarithmic);
         fw->setToolTip(fp->getTooltip());
 //                 fw->setStatusTip(fp->getTooltip());
         fw->setGroup(fp->getGroup());
@@ -452,7 +452,7 @@ void VariableEditor::createWidgetFromGuiParameter(Parser::GuiParameter* p) {
     } else if (dynamic_cast<Parser::Float2Parameter *>(p) != nullptr) {
         auto *f2p = dynamic_cast<Parser::Float2Parameter *>(p);
         QString name = f2p->getName();
-        Float2Widget *f2w = new Float2Widget(currentWidget, this, name, f2p->getDefaultValue(), f2p->getFrom(), f2p->getTo());
+        Float2Widget *f2w = new Float2Widget(currentWidget, this, name, f2p->getDefaultValue(), f2p->getFrom(), f2p->getTo(), f2p->getSliderType() == Logarithmic);
         f2w->setToolTip(f2p->getTooltip());
 //                 f2w->setStatusTip(f2p->getTooltip());
         f2w->setGroup(f2p->getGroup());
@@ -464,7 +464,7 @@ void VariableEditor::createWidgetFromGuiParameter(Parser::GuiParameter* p) {
     } else if (dynamic_cast<Parser::Float3Parameter *>(p) != nullptr) {
         auto *f3p = dynamic_cast<Parser::Float3Parameter *>(p);
         QString name = f3p->getName();
-        Float3Widget *f3w = new Float3Widget(currentWidget, this, name, f3p->getDefaultValue(), f3p->getFrom(), f3p->getTo());
+        Float3Widget *f3w = new Float3Widget(currentWidget, this, name, f3p->getDefaultValue(), f3p->getFrom(), f3p->getTo(), f3p->getSliderType() == Logarithmic);
         f3w->setToolTip(f3p->getTooltip());
 //                 f3w->setStatusTip(f3p->getTooltip());
         f3w->setGroup(f3p->getGroup());
@@ -476,7 +476,7 @@ void VariableEditor::createWidgetFromGuiParameter(Parser::GuiParameter* p) {
     } else if (dynamic_cast<Parser::Float4Parameter *>(p) != nullptr) {
         auto *f4p = dynamic_cast<Parser::Float4Parameter *>(p);
         QString name = f4p->getName();
-        Float4Widget *f4w = new Float4Widget(currentWidget, this, name, f4p->getDefaultValue(), f4p->getFrom(), f4p->getTo());
+        Float4Widget *f4w = new Float4Widget(currentWidget, this, name, f4p->getDefaultValue(), f4p->getFrom(), f4p->getTo(), f4p->getSliderType() == Logarithmic);
         f4w->setToolTip(f4p->getTooltip());
 //                 f4w->setStatusTip(f4p->getTooltip());
         f4w->setGroup(f4p->getGroup());

--- a/Fragmentarium-Source/Fragmentarium/GUI/VariableWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/VariableWidget.cpp
@@ -151,14 +151,14 @@ int VariableWidget::uniformLocation(QOpenGLShaderProgram *shaderProgram)
 }
 
 /// FloatVariable constructor.
-FloatWidget::FloatWidget(QWidget *parent, QWidget *variableEditor, QString name, double defaultValue, double min, double max)
+FloatWidget::FloatWidget(QWidget *parent, QWidget *variableEditor, QString name, double defaultValue, double min, double max, bool logarithmic)
     : VariableWidget(parent, variableEditor, name), defaultValue(defaultValue), min(min), max(max)
 {
     auto *l = new QHBoxLayout(widget);
     l->setSpacing(2);
     l->setContentsMargins (0,0,0,0);
 
-    comboSlider1 = new ComboSlider(parent, variableEditor, defaultValue, min, max);
+    comboSlider1 = new ComboSlider(parent, variableEditor, defaultValue, min, max, logarithmic);
     comboSlider1->setObjectName(QString("%1%2").arg(name).arg("1"));
     l->addWidget(comboSlider1);
     connect(comboSlider1, SIGNAL(changed()), this, SLOT(valueChanged()));
@@ -196,7 +196,7 @@ void FloatWidget::setUserUniform(QOpenGLShaderProgram *shaderProgram)
 
 //// ----- Float2Widget -----------------------------------------------
 
-Float2Widget::Float2Widget(QWidget *parent, QWidget *variableEditor, QString name, glm::dvec2 defaultValue, glm::dvec2 min, glm::dvec2 max)
+Float2Widget::Float2Widget(QWidget *parent, QWidget *variableEditor, QString name, glm::dvec2 defaultValue, glm::dvec2 min, glm::dvec2 max, bool logarithmic)
     : VariableWidget(parent, variableEditor, name), defaultValue(defaultValue), min(min), max(max)
 {
     auto *m = new QGridLayout(widget);
@@ -204,13 +204,13 @@ Float2Widget::Float2Widget(QWidget *parent, QWidget *variableEditor, QString nam
     m->setContentsMargins (0,0,0,0);
 
     comboSlider1 = new ComboSlider(parent, variableEditor, defaultValue.x,
-                                   min.x, max.x);
+                                   min.x, max.x, logarithmic);
     comboSlider1->setObjectName( QString("%1%2").arg(name).arg("1") );
     m->addWidget(comboSlider1,0,1);
     connect(comboSlider1, SIGNAL(changed()), this, SLOT(valueChanged()));
 
     comboSlider2 = new ComboSlider(parent, variableEditor, defaultValue.y,
-                                   min.y, max.y);
+                                   min.y, max.y, logarithmic);
     comboSlider2->setObjectName( QString("%1%2").arg(name).arg("2") );
     m->addWidget(comboSlider2,1,1);
     connect(comboSlider2, SIGNAL(changed()), this, SLOT(valueChanged()));
@@ -258,7 +258,7 @@ void Float2Widget::setUserUniform(QOpenGLShaderProgram *shaderProgram)
 
 //// ----- Float3Widget -----------------------------------------------
 
-Float3Widget::Float3Widget(QWidget *parent, QWidget *variableEditor, QString name, glm::dvec3 defaultValue, glm::dvec3 min, glm::dvec3 max)
+Float3Widget::Float3Widget(QWidget *parent, QWidget *variableEditor, QString name, glm::dvec3 defaultValue, glm::dvec3 min, glm::dvec3 max, bool logarithmic)
     : VariableWidget(parent, variableEditor, name), defaultValue(defaultValue), min(min), max(max)
 {
 
@@ -276,17 +276,17 @@ Float3Widget::Float3Widget(QWidget *parent, QWidget *variableEditor, QString nam
     m->setSpacing(2);
     m->setContentsMargins (0,0,0,0);
 
-    comboSlider1 = new ComboSlider(parent, variableEditor, defaultValue[0], min[0], max[0]);
+    comboSlider1 = new ComboSlider(parent, variableEditor, defaultValue[0], min[0], max[0], logarithmic);
     comboSlider1->setObjectName( QString("%1%2").arg(name).arg("1") );
     m->addWidget(comboSlider1,0,1);
     connect(comboSlider1, SIGNAL(changed()), this, SLOT(n1Changed()));
 
-    comboSlider2 = new ComboSlider(parent, variableEditor, defaultValue[1], min[1], max[1]);
+    comboSlider2 = new ComboSlider(parent, variableEditor, defaultValue[1], min[1], max[1], logarithmic);
     comboSlider2->setObjectName( QString("%1%2").arg(name).arg("2") );
     m->addWidget(comboSlider2,1,1);
     connect(comboSlider2, SIGNAL(changed()), this, SLOT(n2Changed()));
 
-    comboSlider3 = new ComboSlider(parent, variableEditor, defaultValue[2], min[2], max[2]);
+    comboSlider3 = new ComboSlider(parent, variableEditor, defaultValue[2], min[2], max[2], logarithmic);
     comboSlider3->setObjectName( QString("%1%2").arg(name).arg("3") );
     m->addWidget(comboSlider3,2,1);
     connect(comboSlider3, SIGNAL(changed()), this, SLOT(n3Changed()));
@@ -426,7 +426,7 @@ void Float3Widget::setUserUniform(QOpenGLShaderProgram *shaderProgram)
 
 //// ----- Float4Widget -----------------------------------------------
 
-Float4Widget::Float4Widget(QWidget *parent, QWidget *variableEditor, QString name, glm::dvec4 defaultValue, glm::dvec4 min, glm::dvec4 max)
+Float4Widget::Float4Widget(QWidget *parent, QWidget *variableEditor, QString name, glm::dvec4 defaultValue, glm::dvec4 min, glm::dvec4 max, bool logarithmic)
     : VariableWidget(parent, variableEditor, name), defaultValue(defaultValue),
       min(min), max(max)
 {
@@ -444,22 +444,22 @@ Float4Widget::Float4Widget(QWidget *parent, QWidget *variableEditor, QString nam
         normalize = true;
     }
 
-    comboSlider1 = new ComboSlider(parent, variableEditor, defaultValue[0], min[0], max[0]);
+    comboSlider1 = new ComboSlider(parent, variableEditor, defaultValue[0], min[0], max[0], logarithmic);
     comboSlider1->setObjectName( QString("%1%2").arg(name).arg("1") );
     m->addWidget(comboSlider1,0,1);
     connect(comboSlider1, SIGNAL(changed()), this, SLOT(valueChanged()));
 
-    comboSlider2 = new ComboSlider(parent, variableEditor, defaultValue[1], min[1], max[1]);
+    comboSlider2 = new ComboSlider(parent, variableEditor, defaultValue[1], min[1], max[1], logarithmic);
     comboSlider2->setObjectName( QString("%1%2").arg(name).arg("2") );
     m->addWidget(comboSlider2,1,1);
     connect(comboSlider2, SIGNAL(changed()), this, SLOT(valueChanged()));
 
-    comboSlider3 = new ComboSlider(parent, variableEditor, defaultValue[2], min[2], max[2]);
+    comboSlider3 = new ComboSlider(parent, variableEditor, defaultValue[2], min[2], max[2], logarithmic);
     comboSlider3->setObjectName( QString("%1%2").arg(name).arg("3") );
     m->addWidget(comboSlider3,2,1);
     connect(comboSlider3, SIGNAL(changed()), this, SLOT(valueChanged()));
 
-    comboSlider4 = new ComboSlider(parent, variableEditor, defaultValue[3], min[3], max[3]);
+    comboSlider4 = new ComboSlider(parent, variableEditor, defaultValue[3], min[3], max[3], logarithmic);
     comboSlider4->setObjectName( QString("%1%2").arg(name).arg("4") );
     m->addWidget(comboSlider4,3,1);
     connect(comboSlider4, SIGNAL(changed()), this, SLOT(valueChanged()));

--- a/Fragmentarium-Source/Fragmentarium/GUI/VariableWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/VariableWidget.h
@@ -40,8 +40,8 @@ class ComboSlider : public QWidget
     Q_OBJECT
     Q_PROPERTY(double value READ getValue WRITE setValue)
 public:
-    ComboSlider ( QWidget *parent, QWidget *variableEditor, double defaultValue, double minimum, double maximum )
-        : QWidget ( parent ), variableEditor ( variableEditor ), defaultValue ( defaultValue ), minimum ( minimum ), maximum ( maximum )
+    ComboSlider ( QWidget *parent, QWidget *variableEditor, double defaultValue, double minimum, double maximum, bool logarithmic = false)
+        : QWidget ( parent ), variableEditor ( variableEditor ), defaultValue ( defaultValue ), minimum ( minimum ), maximum ( maximum ), logarithmic ( logarithmic )
     {
 
         setMinimumSize(160,20);
@@ -52,11 +52,15 @@ public:
         l->setContentsMargins(0,0,0,0);
 
         // 4294967295
-        scale = (1.0/(maximum-minimum))*(int(__INT32_MAX__*0.5)+1);
+        if (logarithmic) {
+            scale = (1.0/(std::log(maximum)-std::log(minimum)))*(int(__INT32_MAX__*0.5)+1);
+        } else {
+            scale = (1.0/(maximum-minimum))*(int(__INT32_MAX__*0.5)+1);
+        }
 
         slider = new QSlider(Qt::Horizontal,this);
-        slider->setRange(minimum*scale,(maximum*scale)+1);
-        slider->setValue(defaultValue*scale);
+        slider->setRange((logarithmic ? std::log(minimum) : minimum)*scale,((logarithmic ? std::log(maximum) : maximum)*scale)+1);
+        slider->setValue((logarithmic ? std::log(defaultValue) : defaultValue)*scale);
         slider->setSingleStep(scale/1000);
         slider->setPageStep(scale/100);
         slider->setSizePolicy (QSizePolicy ( QSizePolicy::MinimumExpanding, QSizePolicy::Minimum ) );
@@ -137,6 +141,10 @@ public slots:
             QString msg = QString ( tr ( "Clamping" ) + " " + objectName() + " " + tr ( "to min/max range!" ) );
             WARNING( msg );
         }
+        if (logarithmic && ! (d > 0 && minimum > 0 && maximum > 0 && defaultValue > 0)) {
+            // this warns on every change, but WARNING() in the constructor is invisible
+            WARNING("Logarithmic slider " + objectName() + " must be strictly positive!");
+        }
     }
 
 signals:
@@ -149,7 +157,7 @@ protected slots:
         // the slider must be kept quiet while adjusting from spinner
         slider->blockSignals(true);
 
-        slider->setValue(d*scale);
+        slider->setValue((logarithmic ? std::log(d) : d)*scale);
 
         slider->blockSignals(false);
         // let the main gui thread know something happened
@@ -162,7 +170,7 @@ protected slots:
         // the spinner must be kept quiet while adjusting from slider
         spinner->blockSignals(true);
 
-        spinner->setValue(i/scale);
+        spinner->setValue(logarithmic ? std::exp(i/scale) : i/scale);
 
         spinner->blockSignals(false);
         // let the main gui thread know something happened
@@ -176,6 +184,7 @@ private:
     double defaultValue;
     double minimum;
     double maximum;
+    bool logarithmic;
     double scale;
 };
 
@@ -472,7 +481,7 @@ class FloatWidget : public VariableWidget
 public:
     /// FloatVariable constructor.
     FloatWidget ( QWidget *parent, QWidget *variableEditor, QString name,
-                  double defaultValue, double min, double max );
+                  double defaultValue, double min, double max, bool logarithmic );
     virtual QString getUniqueName()
     {
         return QString ( "%1:%2:%3:%4" ).arg ( group ).arg ( getName() ).arg ( min ).arg ( max );
@@ -523,7 +532,7 @@ class Float2Widget : public VariableWidget
 {
 public:
     Float2Widget ( QWidget *parent, QWidget *variableEditor, QString name,
-                   glm::dvec2 defaultValue, glm::dvec2 min, glm::dvec2 max );
+                   glm::dvec2 defaultValue, glm::dvec2 min, glm::dvec2 max, bool logarithmic );
 
     virtual QString getUniqueName()
     {
@@ -591,7 +600,7 @@ class Float3Widget : public VariableWidget
 public:
     /// FloatVariable constructor.
     Float3Widget ( QWidget *parent, QWidget *variableEditor, QString name,
-                   glm::dvec3 defaultValue, glm::dvec3 min, glm::dvec3 max );
+                   glm::dvec3 defaultValue, glm::dvec3 min, glm::dvec3 max, bool logarithmic );
     virtual QString getUniqueName();
     virtual QString getValueAsText()
     {
@@ -660,7 +669,7 @@ class Float4Widget : public VariableWidget
 public:
     /// FloatVariable constructor.
     Float4Widget ( QWidget *parent, QWidget *variableEditor, QString name,
-                   glm::dvec4 defaultValue, glm::dvec4 min, glm::dvec4 max );
+                   glm::dvec4 defaultValue, glm::dvec4 min, glm::dvec4 max, bool logarithmic );
     virtual QString getUniqueName();
     virtual QString getValueAsText()
     {

--- a/Fragmentarium-Source/Fragmentarium/Parser/Preprocessor.cpp
+++ b/Fragmentarium-Source/Fragmentarium/Parser/Preprocessor.cpp
@@ -75,6 +75,20 @@ void setLockType(GuiParameter *p, QString lockTypeString)
     p->setLockType(l);
 }
 
+void setSliderType(GuiParameter *p, QString sliderTypeString)
+{
+    sliderTypeString = sliderTypeString.toLower().trimmed();
+    SliderType l = Linear;
+    if (sliderTypeString == "logarithmic") {
+        l = Logarithmic;
+    } else if (sliderTypeString == "linear" || sliderTypeString.isEmpty()) {
+        l = Linear;
+    } else {
+        WARNING("Not able to parse slider type: " + sliderTypeString + " Default linear!");
+    }
+    p->setSliderType(l);
+}
+
 glm::dvec4 parseQVector4D(QString s1, QString s2, QString s3, QString s4)
 {
     return { parseFloat(s1), parseFloat(s2), parseFloat(s3), parseFloat(s4) };
@@ -415,7 +429,8 @@ void Preprocessor::parseFloat1Slider(FragmentSource *fs, int i)
     }
 
     FloatParameter *fp = new FloatParameter(currentGroup, name, lastComment, from, to, def);
-    setLockType(fp, float1Slider.cap(6));
+    setSliderType(fp, float1Slider.cap(6));
+    setLockType(fp, float1Slider.cap(7));
     if (type.startsWith("d")) fp->setIsDouble(true);
     fs->params.append(fp);
 }
@@ -430,7 +445,8 @@ void Preprocessor::parseFloat2Slider(FragmentSource *fs, int i)
     glm::dvec2 to = parseQVector2D(float2Slider.cap(7), float2Slider.cap(8));
 
     Float2Parameter *fp = new Float2Parameter(currentGroup, name, lastComment, from, to, defaults);
-    setLockType(fp, float2Slider.cap(9));
+    setSliderType(fp, float2Slider.cap(9));
+    setLockType(fp, float2Slider.cap(10));
     if (type.startsWith("d")) fp->setIsDouble(true);
     fs->params.append(fp);
 }
@@ -445,7 +461,8 @@ void Preprocessor::parseFloat3Slider(FragmentSource *fs, int i)
     glm::dvec3 to = parseQVector3D(float3Slider.cap(9), float3Slider.cap(10), float3Slider.cap(11));
 
     Float3Parameter *fp = new Float3Parameter(currentGroup, name, lastComment, from, to, defaults);
-    setLockType(fp, float3Slider.cap(12));
+    setSliderType(fp, float3Slider.cap(12));
+    setLockType(fp, float3Slider.cap(13));
     if (type.startsWith("d")) fp->setIsDouble(true);
     fs->params.append(fp);
 }
@@ -460,7 +477,8 @@ void Preprocessor::parseFloat4Slider(FragmentSource *fs, int i)
     glm::dvec4 to = parseQVector4D(float4Slider.cap(11), float4Slider.cap(12), float4Slider.cap(13), float4Slider.cap(14));
 
     Float4Parameter *fp = new Float4Parameter(currentGroup, name, lastComment, from, to, defaults);
-    setLockType(fp, float4Slider.cap(15));
+    setSliderType(fp, float4Slider.cap(15));
+    setLockType(fp, float4Slider.cap(16));
     if (type.startsWith("d")) fp->setIsDouble(true);
     fs->params.append(fp);
 }

--- a/Fragmentarium-Source/Fragmentarium/Parser/Preprocessor.h
+++ b/Fragmentarium-Source/Fragmentarium/Parser/Preprocessor.h
@@ -79,6 +79,51 @@ private:
     LockTypeInner inner = NotLocked;
 };
 
+enum SliderTypeInner { Linear, Logarithmic, UnknownSliderType } ;
+
+class SliderType {
+public:
+    SliderType() {}
+    SliderType(QString s) {
+        fromString(s);
+    }
+    SliderType(SliderTypeInner l) : inner(l) {}
+    bool operator ==(const SliderTypeInner lty) {
+        return inner==lty;
+    }
+    bool operator !=(const SliderTypeInner lty) {
+        return inner!=lty;
+    }
+    bool operator ==(const SliderType &lty) {
+        return inner==lty.inner;
+    }
+    bool operator !=(const SliderType &lty) {
+        return inner!=lty.inner;
+    }
+    QString toString() {
+        if (inner == Linear) {
+            return "Linear";
+        } else if (inner == Logarithmic) {
+            return "Logarithmic";
+        } else {
+            return "???";
+        }
+    }
+
+    void fromString(QString s) {
+        s = s.toLower();
+        if (s == "linear") {
+            inner = Linear;
+        } else if (s == "logarithmic") {
+            inner = Logarithmic;
+        } else {
+            inner = UnknownSliderType;
+        }
+    }
+
+private:
+    SliderTypeInner inner = Linear;
+};
 
 class GuiParameter {
 public:
@@ -101,6 +146,12 @@ public:
     void setLockType(LockType l) {
         lockType = l;
     }
+    SliderType getSliderType() {
+        return sliderType;
+    }
+    void setSliderType(SliderType l) {
+        sliderType = l;
+    }
     void setIsDouble(bool v) {
         wantDouble = v;
     }
@@ -109,6 +160,7 @@ public:
     }
 protected:
     LockType lockType;
+    SliderType sliderType;
     QString group;
     QString name;
     QString tooltip;
@@ -341,13 +393,14 @@ public:
 };
 
 /// The preprocessor is responsible for including files and resolve user uniform variables
+    const QString sliderTypeString = "\\s*(Linear|Logarithmic)?";
     const QString lockTypeString = "\\s*(Locked|NotLocked|NotLockable)?\\s*.?$";
 
     // Look for patterns like 'uniform float varName; slider[0.1,1,2.0]'
-    static QRegExp float4Slider ( "^\\s*uniform\\s+([d]{0,1}vec4)\\s+(\\S+)\\s*;\\s*slider\\[\\((\\S+),(\\S+),(\\S+),(\\S+)\\),\\((\\S+),(\\S+),(\\S+),(\\S+)\\),\\((\\S+),(\\S+),(\\S+),(\\S+)\\)\\]"+lockTypeString );
-    static QRegExp float3Slider ( "^\\s*uniform\\s+([d]{0,1}vec3)\\s+(\\S+)\\s*;\\s*slider\\[\\((\\S+),(\\S+),(\\S+)\\),\\((\\S+),(\\S+),(\\S+)\\),\\((\\S+),(\\S+),(\\S+)\\)\\]"+lockTypeString );
-    static QRegExp float2Slider ( "^\\s*uniform\\s+([d]{0,1}vec2)\\s+(\\S+)\\s*;\\s*slider\\[\\((\\S+),(\\S+)\\),\\((\\S+),(\\S+)\\),\\((\\S+),(\\S+)\\)\\]"+lockTypeString );
-    static QRegExp float1Slider ( "^\\s*uniform\\s+([float|double]{1,6})\\s+(\\S+)\\s*;\\s*slider\\[(\\S+),(\\S+),(\\S+)\\]"+lockTypeString );
+    static QRegExp float4Slider ( "^\\s*uniform\\s+([d]{0,1}vec4)\\s+(\\S+)\\s*;\\s*slider\\[\\((\\S+),(\\S+),(\\S+),(\\S+)\\),\\((\\S+),(\\S+),(\\S+),(\\S+)\\),\\((\\S+),(\\S+),(\\S+),(\\S+)\\)\\]"+sliderTypeString+lockTypeString );
+    static QRegExp float3Slider ( "^\\s*uniform\\s+([d]{0,1}vec3)\\s+(\\S+)\\s*;\\s*slider\\[\\((\\S+),(\\S+),(\\S+)\\),\\((\\S+),(\\S+),(\\S+)\\),\\((\\S+),(\\S+),(\\S+)\\)\\]"+sliderTypeString+lockTypeString );
+    static QRegExp float2Slider ( "^\\s*uniform\\s+([d]{0,1}vec2)\\s+(\\S+)\\s*;\\s*slider\\[\\((\\S+),(\\S+)\\),\\((\\S+),(\\S+)\\),\\((\\S+),(\\S+)\\)\\]"+sliderTypeString+lockTypeString );
+    static QRegExp float1Slider ( "^\\s*uniform\\s+([float|double]{1,6})\\s+(\\S+)\\s*;\\s*slider\\[(\\S+),(\\S+),(\\S+)\\]"+sliderTypeString+lockTypeString );
 
     static QRegExp colorChooser ( "^\\s*uniform\\s+([d]{0,1}vec3)\\s+(\\S+)\\s*;\\s*color\\[(\\S+),(\\S+),(\\S+)\\]"+lockTypeString );
     static QRegExp floatColorChooser ( "^\\s*uniform\\s+([d]{0,1}vec4)\\s+(\\S+)\\s*;\\s*color\\[(\\S+),(\\S+),(\\S+),(\\S+),(\\S+),(\\S+)\\]"+lockTypeString );


### PR DESCRIPTION
Fixes: <https://github.com/3Dickulus/FragM/issues/33>

Syntax: new string (Linear|Logarithmic)? after slider, before any lock spec.

Examples:

```
uniform float Zoom; slider[1e-4,1,1e16] Logarithmic NotLockable
uniform vec2 Potato; slider[(-10,10),(4,2),(10,10)] Linear
uniform vec3 Potathree; slider[(-10,10),(4,2),(10,10)] // default linear
```

Implementation:

Parser has SliderType(Inner) class/enum, which is owned by GuiParameter.
Parser uses regex to capture it and setSliderType() accordingly.

ComboSlider: has a logarithmic bool argument to its constructor that
makes the slider logarithmic.  Range must be strictly positive, otherwise
the slider is inoperable and warnings are printed to the log.

Float(2|3|4)?Widget: has a logarithmic bool argument to the constructor
which is passed down to the ComboSlider(s).

VariableEditor passes the slider type from the GuiParameter to the
FloatWidget constructor.