### PR TITLE
[feature] camera 2d skew

### DIFF
--- a/Fragmentarium-Source/Examples/Include/2D.frag
+++ b/Fragmentarium-Source/Examples/Include/2D.frag
@@ -14,6 +14,10 @@ uniform vec2 Center; slider[(-10,-10),(0,0),(10,10)] NotLockable
 uniform float Zoom; slider[0,1,100] NotLockable
 uniform float AntiAliasScale;slider[0.0,1,2] NotLockable
 
+uniform bool EnableTransform; checkbox[true]
+uniform float RotateAngle; slider[-360,0,360]
+uniform float StretchAngle; slider[-360,0,360]
+uniform float StretchAmount; slider[-100,0,100]
 
 uniform vec2 pixelSize;
 
@@ -23,10 +27,26 @@ varying vec2 viewCoord;
 
 void main(void)
 {
+	mat2 transform = mat2(1.0, 0.0, 0.0, 1.0);
+	if (EnableTransform)
+	{
+		float b = radians(RotateAngle);
+		float bc = cos(b);
+		float bs = sin(b);
+		float a = radians(StretchAngle);
+		float ac = cos(a);
+		float as = sin(a);
+		float s = sqrt(pow(2.0, StretchAmount));
+		mat2 m1 = mat2(ac, as, -as, ac);
+		mat2 m2 = mat2(s, 0.0, 0.0, 1.0 / s);
+		mat2 m3 = mat2(ac, -as, as, ac);
+		mat2 m4 = mat2(bc, bs, -bs, bc);
+		transform = m1 * m2 * m3 * m4;
+	}
 	float ar = pixelSize.y/pixelSize.x;
 	gl_Position =  gl_Vertex;
 	viewCoord = (gl_ProjectionMatrix*gl_Vertex).xy;
-	coord = (((gl_ProjectionMatrix*gl_Vertex).xy*vec2(ar,1.0))/Zoom+  Center);
+	coord = (transform*((gl_ProjectionMatrix*gl_Vertex).xy*vec2(ar,1.0))/Zoom+  Center);
 	aaScale = vec2(gl_ProjectionMatrix[0][0],gl_ProjectionMatrix[1][1])*pixelSize*AntiAliasScale/Zoom;
 }
 
@@ -50,9 +70,9 @@ vec3 getColor2Daa(vec2 z) {
 	vec2 ard = vec2(pixelSize.x,pixelSize.y)*d;
 	for (int x=0; x <AntiAlias;x++) {
 		for (int y=0; y <AntiAlias;y++) {
-		       aaCoord = (viewCoord + vec2(x,y)*ard);
+					 aaCoord = (viewCoord + vec2(x,y)*ard);
 			v +=  color(z+vec2(x,y)*d*aaScale);
-             }
+						 }
 	}
 
 	return v/(float(AntiAlias*AntiAlias));

--- a/Fragmentarium-Source/Examples/Include/Progressive2D-4.frag
+++ b/Fragmentarium-Source/Examples/Include/Progressive2D-4.frag
@@ -17,15 +17,36 @@ out vec2 viewCoord;
 uniform dvec2 Center; slider[(-100,-100),(0,0),(100,100)] NotLockable
 uniform double Zoom; slider[0,1,1e16] NotLockable
 
+uniform bool EnableTransform; checkbox[true]
+uniform float RotateAngle; slider[-360,0,360]
+uniform float StretchAngle; slider[-360,0,360]
+uniform float StretchAmount; slider[-100,0,100]
+
 uniform vec2 pixelSize;
 
 
 void main(void)
 {
-	double ar = pixelSize.y/pixelSize.x;
+	mat2 transform = mat2(1.0, 0.0, 0.0, 1.0);
+	if (EnableTransform)
+	{
+		float b = radians(RotateAngle);
+		float bc = cos(b);
+		float bs = sin(b);
+		float a = radians(StretchAngle);
+		float ac = cos(a);
+		float as = sin(a);
+		float s = sqrt(pow(2.0, StretchAmount));
+		mat2 m1 = mat2(ac, as, -as, ac);
+		mat2 m2 = mat2(s, 0.0, 0.0, 1.0 / s);
+		mat2 m3 = mat2(ac, -as, as, ac);
+		mat2 m4 = mat2(bc, bs, -bs, bc);
+		transform = m1 * m2 * m3 * m4;
+	}
+	float ar = pixelSize.y/pixelSize.x;
 	gl_Position =  gl_Vertex;
 	viewCoord = gl_Vertex.xy;
-	coord = vec2(((gl_ProjectionMatrix*gl_Vertex).xy*vec2(ar,1.0))/float(Zoom));
+	coord = vec2(transform * ((gl_ProjectionMatrix*gl_Vertex).xy*vec2(ar,1.0))/float(Zoom));
 	aaScale = vec2(gl_ProjectionMatrix[0][0],gl_ProjectionMatrix[1][1])*pixelSize/float(Zoom);
 }
 

--- a/Fragmentarium-Source/Examples/Include/Progressive2D.frag
+++ b/Fragmentarium-Source/Examples/Include/Progressive2D.frag
@@ -15,6 +15,11 @@
 uniform vec2 Center; slider[(-10,-10),(0,0),(10,10)] NotLockable
 uniform float Zoom; slider[0,1,100000] NotLockable
 
+uniform bool EnableTransform; checkbox[true]
+uniform float RotateAngle; slider[-360,0,360]
+uniform float StretchAngle; slider[-360,0,360]
+uniform float StretchAmount; slider[-100,0,100]
+
 uniform vec2 pixelSize;
 
 varying vec2 coord;
@@ -23,10 +28,26 @@ varying vec2 viewCoord;
 
 void main(void)
 {
+	mat2 transform = mat2(1.0, 0.0, 0.0, 1.0);
+	if (EnableTransform)
+	{
+		float b = radians(RotateAngle);
+		float bc = cos(b);
+		float bs = sin(b);
+		float a = radians(StretchAngle);
+		float ac = cos(a);
+		float as = sin(a);
+		float s = sqrt(pow(2.0, StretchAmount));
+		mat2 m1 = mat2(ac, as, -as, ac);
+		mat2 m2 = mat2(s, 0.0, 0.0, 1.0 / s);
+		mat2 m3 = mat2(ac, -as, as, ac);
+		mat2 m4 = mat2(bc, bs, -bs, bc);
+		transform = m1 * m2 * m3 * m4;
+	}
 	float ar = pixelSize.y/pixelSize.x;
 	gl_Position =  gl_Vertex;
 	viewCoord = (gl_Vertex).xy;
-	coord = (((gl_ProjectionMatrix*gl_Vertex).xy*vec2(ar,1.0))/Zoom+  Center);
+	coord = (transform * ((gl_ProjectionMatrix*gl_Vertex).xy*vec2(ar,1.0))/Zoom+  Center);
 	aaScale = vec2(gl_ProjectionMatrix[0][0],gl_ProjectionMatrix[1][1])*pixelSize/Zoom;
 }
 

--- a/Fragmentarium-Source/Fragmentarium/GUI/CameraControl.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/CameraControl.cpp
@@ -593,12 +593,12 @@ bool Camera2D::parseKeys()
 
 
     if (keyDown(Qt::Key_W)) {
-        center->setValue(centerValue + glm::dvec3(getTransform() * glm::dvec2(0.0, -zFactor), 0.0));
+        center->setValue(centerValue + glm::dvec3(getTransform() * glm::dvec2(0.0, zFactor), 0.0));
         keysDown = true;
     }
 
     if (keyDown(Qt::Key_S)) {
-        center->setValue(centerValue + glm::dvec3(getTransform() * glm::dvec2(0.0, zFactor), 0.0));
+        center->setValue(centerValue + glm::dvec3(getTransform() * glm::dvec2(0.0, -zFactor), 0.0));
         keysDown = true;
     }
 

--- a/Fragmentarium-Source/Fragmentarium/GUI/CameraControl.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/CameraControl.h
@@ -19,6 +19,7 @@ class VariableEditor;
 class Float3Widget;
 class Float2Widget;
 class FloatWidget;
+class BoolWidget;
 
 // CameraControl maintains camera position, and respond to user control.
 class CameraControl : public QObject
@@ -124,11 +125,16 @@ public:
     virtual bool parseKeys();
     virtual void reset(bool fullReset);
     virtual double StepSize();
+    virtual glm::dmat2 getTransform();
 private:
     int height;
     int width;
     Float2Widget* center;
     FloatWidget* zoom;
+    BoolWidget* enableTransform;
+    FloatWidget* rotateAngle;
+    FloatWidget* stretchAngle;
+    FloatWidget* stretchAmount;
     QStatusBar* statusBar;
     glm::dvec3 mouseDown;
     double zoomDown;


### PR DESCRIPTION
*   extend 2D camera with rotation and skew support
    
    Adds support to the 2D camera for rotation and skew, via these
    uniforms in the 2D and Progressive2D(-4) frags:
    
        uniform bool EnableTransform; checkbox[true]
        uniform float RotateAngle; slider[-360,0,360]
        uniform float StretchAngle; slider[-360,0,360]
        uniform float StretchAmount; slider[-100,0,100]
    
    The core is modified to duplicate the transformation matrix
    applied to the coordinates in the frag code, so that mouse and
    keyboard actions correspond to the displayed image.
    
    Allows exploring "hidden treasures" in skewed regions of the
    Burning Ship etc.

*   swap W and S keys in Camera2D for sanity