### PR TITLE
[feature] buffershader gui

### DIFF
--- a/Fragmentarium-Source/Examples/Include/3D.frag
+++ b/Fragmentarium-Source/Examples/Include/3D.frag
@@ -106,17 +106,6 @@ void init() {}
 
 #group Post
 uniform float Gamma; slider[0.0,2.0,5.0];
-// 1: Linear, 2: Expontial, 3: Filmic, 4: Reinhart; 5: Syntopia
-uniform int ToneMapping; slider[1,4,5];
-uniform float Exposure; slider[0.0,1.0,3.0];
-uniform float Brightness; slider[0.0,1.0,5.0];
-uniform float Contrast; slider[0.0,1.0,5.0];
-// Affects Contrast
-uniform vec3 AvgLumin; color[0.5,0.5,0.5];
-uniform float Saturation; slider[0.0,1.0,5.0];
-// Affects Saturation
-uniform vec3 LumCoeff; color[0.2125,0.7154,0.0721];
-uniform float Hue; slider[0,0,1.0];
 uniform float GaussianWeight; slider[0.0,1.0,10.0];
 uniform float AntiAliasScale; slider[0,2,10];
 

--- a/Fragmentarium-Source/Examples/Include/3DKn-1.0.1.frag
+++ b/Fragmentarium-Source/Examples/Include/3DKn-1.0.1.frag
@@ -33,7 +33,6 @@ uniform vec2 pixelSize;
 varying vec2 coord;
 varying vec2 viewCoord;
 varying vec2 viewCoord2;
-varying vec3 dir;
 varying vec3 Dir;
 varying vec3 UpOrtho;
 varying vec3 Right;
@@ -98,7 +97,6 @@ uniform bool ApStarShaped; checkbox[false] Locked
 
 // Camera position and target.
 varying vec3 from;
-varying vec3 dir;
 varying vec3 dirDx;
 varying vec3 dirDy;
 varying vec2 coord;
@@ -160,26 +158,8 @@ void init() {}
 //out vec4 gl_FragColor;
 #group Post
 uniform float Gamma; slider[0.0,1.0,5.0]
-// 1: Linear, 2: Expontial, 3: Filmic, 4: Reinhart; 5: Syntopia
-uniform int ToneMapping; slider[1,1,5]
-uniform float Exposure; slider[0.0,1.0,3.0]
-uniform float Brightness; slider[0.0,1.0,5.0];
-uniform float Contrast; slider[0.0,1.0,5.0];
-uniform float Saturation; slider[0.0,1.0,5.0];
 uniform float GaussianWeight; slider[0.0,1.0,10.0];
-
 uniform float AntiAliasScale; slider[0,2,10]
-//Apply Bloom. Note: specularity parameters (Light tab) have a huge impact.
-uniform bool  Bloom; checkbox[false]
-uniform float BloomIntensity; slider[0,0.25,2]
-uniform float BloomPow; slider[0,2,30]
-uniform int   BloomTaps; slider[1,4,160]
-uniform bool  LensFlare; checkbox[false]
-uniform float FlareIntensity; slider[0.0,0.25,2]
-uniform int   FlareSamples; slider[1,8,9]
-uniform float FlareDispersal; slider[0.0,0.25,1.0]
-uniform float FlareHaloWidth; slider[0.0,0.5,1.0]
-uniform float FlareDistortion; slider[0.0,1.0,2.0]
 
 varying vec2 PixelScale;
 uniform float FOV;

--- a/Fragmentarium-Source/Examples/Include/3DKn-1.0.5.frag
+++ b/Fragmentarium-Source/Examples/Include/3DKn-1.0.5.frag
@@ -146,26 +146,8 @@ void init() {}
 
 #group Post
 uniform float Gamma; slider[0.0,1.0,5.0]
-// 1: Linear, 2: Expontial, 3: Filmic, 4: Reinhart; 5: Syntopia
-uniform int ToneMapping; slider[1,1,5]
-uniform float Exposure; slider[0.0,1.0,3.0]
-uniform float Brightness; slider[0.0,1.0,5.0];
-uniform float Contrast; slider[0.0,1.0,5.0];
-uniform float Saturation; slider[0.0,1.0,5.0];
 uniform float GaussianWeight; slider[0.0,1.0,10.0];
 uniform float AntiAliasScale; slider[0,2.5,10]
-//Apply Bloom. Note: specularity parameters (Light tab) have a huge impact.
-uniform bool Bloom; checkbox[false]
-uniform float BloomIntensity; slider[0,0,2]
-uniform float BloomPow; slider[0,2,10]
-uniform int   BloomTaps; slider[1,4,100]
-uniform float BloomStrong; slider[1,1,20]
-uniform bool  LensFlare; checkbox[false]
-uniform float FlareIntensity; slider[0.0,0.25,2]
-uniform int   FlareSamples; slider[1,8,9]
-uniform float FlareDispersal; slider[0.0,0.25,1.0]
-uniform float FlareHaloWidth; slider[0.0,0.5,1.0]
-uniform float FlareDistortion; slider[0.0,1.0,2.0]
 
 varying vec2 PixelScale;
 uniform float FOV;

--- a/Fragmentarium-Source/Examples/Include/Brute-Raytracer.frag
+++ b/Fragmentarium-Source/Examples/Include/Brute-Raytracer.frag
@@ -7,16 +7,10 @@
 
 #group Raytracer
 
-uniform float NormalScale;slider[0,1,5]
-uniform float AOScale;slider[0,1,5]
-uniform float Glow;slider[0,0.1,1]
-uniform float AOStrength;slider[0,0.6,1]
-
 // Maximum number of  raymarching steps.
 uniform int Samples;  slider[0,40,2000]
 uniform bool Stratify; checkbox[true]
 uniform bool DebugInside; checkbox[false]
-uniform bool CentralDifferences; checkbox[true]
 uniform bool SampleNeighbors; checkbox[true]
 
 uniform float Near; slider[0,0,12]
@@ -24,23 +18,6 @@ uniform float Far; slider[0,5,12]
 
 // Available when using exr image filename extention
 uniform bool DepthToAlpha; checkbox[false];
-
-uniform bool  DebugNormals; checkbox[false]
-
-#group Light
-
-// The specular intensity of the directional light
-uniform float Specular; slider[0,4.0,10.0];
-// The specular exponent
-uniform float SpecularExp; slider[0,16.0,100.0];
-// Color and strength of the directional light
-uniform vec4 SpotLight; color[0.0,0.4,1.0,1.0,1.0,1.0];
-// Direction to the spot light (spherical coordinates)
-uniform vec2 SpotLightDir;  slider[(-1,-1),(0.1,0.1),(1,1)]
-// Light coming from the camera position (diffuse lightning)
-uniform vec4 CamLight; color[0,0.3,2,1.0,1.0,1.0];
-// Controls the minimum ambient light, regardless of directionality
-uniform float CamLightMin; slider[0.0,0.0,1.0]
 
 uniform float Fog; slider[0,0.0,2]
 

--- a/Fragmentarium-Source/Examples/Include/Brute3D.frag
+++ b/Fragmentarium-Source/Examples/Include/Brute3D.frag
@@ -96,14 +96,6 @@ void init(); // forward declare
 void init() {}
 #endif
 //out vec4 gl_FragColor;
-#group Post
-uniform float Gamma; slider[0.0,1.0,5.0]
-// 1: Linear, 2: Expontial, 3: Filmic, 4: Reinhart
-uniform int ToneMapping; slider[1,1,4]
-uniform float Exposure; slider[0.0,1.0,3.0]
-uniform float Brightness; slider[0.0,1.0,5.0];
-uniform float Contrast; slider[0.0,1.0,5.0];
-uniform float Saturation; slider[0.0,1.0,5.0];
 
 varying vec2 PixelScale;
 uniform float FOV;

--- a/Fragmentarium-Source/Examples/Include/BufferShader-1.0.1.frag
+++ b/Fragmentarium-Source/Examples/Include/BufferShader-1.0.1.frag
@@ -14,16 +14,23 @@ void main(void)
 
 #endvertex
 
+#group Post
+
 uniform float Gamma;
-uniform int ToneMapping;
-uniform float Exposure;
-uniform float Brightness;
-uniform float Contrast;
-uniform float Saturation;
-uniform bool Bloom;
-uniform float BloomIntensity;
-uniform float BloomPow;
-uniform int   BloomTaps;
+
+// 1: Linear, 2: Expontial, 3: Filmic, 4: Reinhart; 5: Syntopia
+uniform int ToneMapping; slider[1,1,5]
+uniform float Exposure; slider[0.0,1.0,3.0]
+uniform float Brightness; slider[0.0,1.0,5.0];
+uniform float Contrast; slider[0.0,1.0,5.0];
+uniform float Saturation; slider[0.0,1.0,5.0];
+
+#group Bloom
+//Apply Bloom. Note: specularity parameters (Light tab) have a huge impact.
+uniform bool  Bloom; checkbox[false]
+uniform float BloomIntensity; slider[0,0.25,2]
+uniform float BloomPow; slider[0,2,30]
+uniform int   BloomTaps; slider[1,4,160]
 
 /*
 ** Based on: http://mouaif.wordpress.com/2009/01/22/photoshop-gamma-correction-shader/
@@ -63,12 +70,16 @@ uniform sampler2D frontbuffer;
 /*----------------------------------------------------------------------------*/
 // modified from...
 // http://john-chapman-graphics.blogspot.ca/2013/02/pseudo-lens-flare.html
-uniform bool LensFlare;
-uniform float FlareIntensity;
-uniform int   FlareSamples;
-uniform float FlareDispersal;
-uniform float FlareHaloWidth;
-uniform float FlareDistortion;
+
+#group Flare
+uniform bool  LensFlare; checkbox[false]
+uniform float FlareIntensity; slider[0.0,0.25,2]
+uniform int   FlareSamples; slider[1,8,9]
+uniform float FlareDispersal; slider[0.0,0.25,1.0]
+uniform float FlareHaloWidth; slider[0.0,0.5,1.0]
+uniform float FlareDistortion; slider[0.0,1.0,2.0]
+
+
 
 vec4 textureDistorted(
         in vec2 texcoord,

--- a/Fragmentarium-Source/Examples/Include/BufferShader-4.frag
+++ b/Fragmentarium-Source/Examples/Include/BufferShader-4.frag
@@ -22,11 +22,12 @@ out vec4 FragColor;
 #group Post
 
 uniform double Gamma;
-uniform double Exposure;
-uniform double Brightness;
-uniform double Contrast;
-uniform double Saturation;
-uniform int ToneMapping;
+uniform double Exposure; slider[0.0,1.0,30.0]
+uniform double Brightness; slider[0.0,1.0,5.0]
+uniform double Contrast; slider[0.0,1.0,5.0]
+uniform double Saturation; slider[0.0,1.0,5.0]
+// 1: Linear, 2: Exponential, 3: Filmic, 4: Reinhart
+uniform int ToneMapping; slider[1,1,4]
 
 /*
 ** Based on: http://mouaif.wordpress.com/2009/01/22/photoshop-gamma-correction-shader/

--- a/Fragmentarium-Source/Examples/Include/BufferShader.frag
+++ b/Fragmentarium-Source/Examples/Include/BufferShader.frag
@@ -14,15 +14,20 @@ void main(void)
 
 #endvertex
 
-uniform float Gamma;
-uniform float Exposure;
-uniform float Brightness;
-uniform float Contrast;
-uniform float Saturation;
-uniform int ToneMapping;
-uniform float Hue;
-uniform vec3 LumCoeff;
-uniform vec3 AvgLumin;
+#group Post
+
+uniform float Gamma; // widget in Main frag (eg Progressive2D)
+
+// 1: Linear, 2: Exponential, 3: Filmic, 4: Reinhart
+uniform int ToneMapping; slider[1,1,4]
+uniform float Exposure; slider[0.0,1.0,30.0]
+uniform float Brightness; slider[0.0,1.0,5.0];
+uniform float Contrast; slider[0.0,1.0,5.0];
+uniform float Saturation; slider[0.0,1.0,5.0];
+
+uniform float Hue; slider[0,0,1]
+uniform vec3 LumCoeff; color[1,1,1]
+uniform vec3 AvgLumin; color[0,0,0]
 
 // RGB <-> HSV conversion, thanks to http://lolengine.net/blog/2013/07/27/rgb-to-hsv-in-glsl
 vec3 rgb2hsv(vec3 c)

--- a/Fragmentarium-Source/Examples/Include/DepthBufferShader.frag
+++ b/Fragmentarium-Source/Examples/Include/DepthBufferShader.frag
@@ -34,12 +34,15 @@ void main(void)
 
 #endvertex
 
-uniform float Gamma;
-uniform float Exposure;
-uniform float Brightness;
-uniform float Contrast;
-uniform float Saturation;
-uniform int ToneMapping;
+#group Post
+uniform float Gamma; slider[0.0,1.0,5.0]
+// 1: Linear, 2: Expontial, 3: Filmic, 4: Reinhart
+uniform int ToneMapping; slider[1,1,4]
+uniform float Exposure; slider[0.0,1.0,3.0]
+uniform float Brightness; slider[0.0,1.0,5.0];
+uniform float Contrast; slider[0.0,1.0,5.0];
+uniform float Saturation; slider[0.0,1.0,5.0];
+
 /*
 ** Based on: http://mouaif.wordpress.com/2009/01/22/photoshop-gamma-correction-shader/
 **
@@ -65,23 +68,30 @@ varying vec2 coord;
 varying vec2 viewCoord;
 uniform sampler2D frontbuffer;
 uniform bool ShowDepth;
-uniform bool DebugNormals;
-uniform float NormalScale;
-uniform float AOScale;
 
+#group Raytracer
+
+uniform float NormalScale;slider[0,1,5]
+uniform float AOScale;slider[0,1,5]
+uniform float Glow;slider[0,0.1,1]
+uniform float AOStrength;slider[0,0.6,1]
+uniform bool CentralDifferences; checkbox[true]
+uniform bool DebugNormals; checkbox[false]
+
+#group Light
 
 // The specular intensity of the directional light
-uniform float Specular;
+uniform float Specular; slider[0,4.0,10.0];
 // The specular exponent
-uniform float SpecularExp;
+uniform float SpecularExp; slider[0,16.0,100.0];
 // Color and strength of the directional light
-uniform vec4 SpotLight;
+uniform vec4 SpotLight; color[0.0,0.4,1.0,1.0,1.0,1.0];
 // Direction to the spot light (spherical coordinates)
-uniform vec2 SpotLightDir;
+uniform vec2 SpotLightDir;  slider[(-1,-1),(0.1,0.1),(1,1)]
 // Light coming from the camera position (diffuse lightning)
-uniform vec4 CamLight;
+uniform vec4 CamLight; color[0,0.3,2,1.0,1.0,1.0];
 // Controls the minimum ambient light, regardless of directionality
-uniform float CamLightMin;
+uniform float CamLightMin; slider[0.0,0.0,1.0]
 
 uniform float FOV;
 uniform vec3 Eye;
@@ -98,8 +108,7 @@ float rand(vec2 co){
 }
 
 uniform int subframe;
-uniform float Glow;
-uniform float AOStrength;
+
 uniform float Near;
 uniform float Far;
 uniform vec2 globalPixelSize;
@@ -108,7 +117,6 @@ uniform vec2 pixelSize;
 varying vec3 Dir;
 varying vec3 UpOrtho;
 varying vec3 Right;
-uniform bool CentralDifferences; 
 
 void main() {
 	vec2 pos = (coord+vec2(1.0))/2.0;

--- a/Fragmentarium-Source/Examples/Include/Progressive2D-4.frag
+++ b/Fragmentarium-Source/Examples/Include/Progressive2D-4.frag
@@ -36,12 +36,6 @@ uniform dvec2 Center;
 #group Post
 
 uniform double Gamma; slider[0.0,2.2,5.0]
-uniform double Exposure; slider[0.0,1.0,30.0]
-uniform double Brightness; slider[0.0,1.0,5.0]
-uniform double Contrast; slider[0.0,1.0,5.0]
-uniform double Saturation; slider[0.0,1.0,5.0]
-// 1: Linear, 2: Exponential, 3: Filmic, 4: Reinhart
-uniform int ToneMapping; slider[1,1,4]
 uniform double AARange; slider[0.0,2.,15.3]
 uniform double AAExp; slider[0.0,1,15.3]
 uniform bool GaussianAA; checkbox[true]

--- a/Fragmentarium-Source/Examples/Include/Progressive2D.frag
+++ b/Fragmentarium-Source/Examples/Include/Progressive2D.frag
@@ -34,12 +34,6 @@ void main(void)
 
 #group Post
 uniform float Gamma; slider[0.0,2.2,5.0]
-// 1: Linear, 2: Exponential, 3: Filmic, 4: Reinhart
-uniform int ToneMapping; slider[1,1,4]
-uniform float Exposure; slider[0.0,1.0,30.0]
-uniform float Brightness; slider[0.0,1.0,5.0];
-uniform float Contrast; slider[0.0,1.0,5.0];
-uniform float Saturation; slider[0.0,1.0,5.0];
 
 uniform float AARange; slider[0.0,2.,15.3]
 uniform float AAExp; slider[0.0,1,15.3]

--- a/Fragmentarium-Source/Examples/TestSuite/BufferShaderUniforms_BufferShader.frag
+++ b/Fragmentarium-Source/Examples/TestSuite/BufferShaderUniforms_BufferShader.frag
@@ -1,0 +1,28 @@
+#donotrun
+
+#vertex
+
+varying vec2 coord;
+
+void main(void)
+{
+  gl_Position =  gl_Vertex;
+  coord = ((gl_ProjectionMatrix * gl_Vertex).xy + vec2(1.0)) * 0.5;
+}
+
+#endvertex
+
+varying vec2 coord;
+
+uniform sampler2D frontbuffer;
+
+#group Post
+
+uniform float Exposure; slider[-10.0,0.0,10.0]
+
+void main(void)
+{
+  vec4 tex = texture2D(frontbuffer, coord);
+  vec3 c = pow(2.0, Exposure) * tex.xyz / tex.a;
+  gl_FragColor = vec4(clamp(c, 0.0, 1.0), 1.0);
+}

--- a/Fragmentarium-Source/Examples/TestSuite/BufferShaderUniforms_Main.frag
+++ b/Fragmentarium-Source/Examples/TestSuite/BufferShaderUniforms_Main.frag
@@ -1,0 +1,57 @@
+#version 130
+
+#camera 2D
+
+#buffer RGBA32F
+#buffershader "BufferShaderUniforms_BufferShader.frag"
+
+#vertex
+
+out vec2 coord;
+out vec2 viewCoord;
+
+#group Camera
+
+uniform float Zoom; slider[1e-4,1,1e16] NotLockable
+uniform vec2 pixelSize;
+
+void main(void)
+{
+  float ar = float(pixelSize.y / pixelSize.x);
+  coord = ((gl_ProjectionMatrix * gl_Vertex).xy * vec2(ar, 1.0)) / Zoom;
+  viewCoord = gl_Vertex.xy;
+  gl_Position =  gl_Vertex;
+}
+
+#endvertex
+
+in vec2 coord;
+in vec2 viewCoord;
+
+out vec4 fragColor;
+
+uniform vec2 Center; slider[(-100,-100),(0,0),(100,100)] NotLockable
+
+uniform sampler2D backbuffer;
+
+vec3 color(vec2 p)
+{
+  int x = int(floor(16777216.0 * p.x)) & 0xFFFFFF;
+  int y = int(floor(16777216.0 * p.y)) & 0xFFFFFF;
+  int u = x ^ y;
+  float g = float(u) / 16777216.0;
+  return vec3(g);
+}
+
+void main()
+{
+  vec2 p = coord;
+  next = vec4(color(p + vec2(Center)), 1.0);
+  vec4 prev = texture(backbuffer, vec2(viewCoord + vec2(1.0)) * 0.5);
+  if (! (next == next)) // NaN check
+  {
+    next = vec4(0.0);
+  }
+  fragColor = vec4(prev + vec4(next.xyz * next.w, next.w));
+}
+

--- a/Fragmentarium-Source/Examples/TestSuite/BufferShaderUniforms_Main.frag
+++ b/Fragmentarium-Source/Examples/TestSuite/BufferShaderUniforms_Main.frag
@@ -46,7 +46,7 @@ vec3 color(vec2 p)
 void main()
 {
   vec2 p = coord;
-  next = vec4(color(p + vec2(Center)), 1.0);
+  vec4 next = vec4(color(p + vec2(Center)), 1.0);
   vec4 prev = texture(backbuffer, vec2(viewCoord + vec2(1.0)) * 0.5);
   if (! (next == next)) // NaN check
   {

--- a/Fragmentarium-Source/Examples/TestSuite/BufferShaderUniforms_MainWithoutBufferShader.frag
+++ b/Fragmentarium-Source/Examples/TestSuite/BufferShaderUniforms_MainWithoutBufferShader.frag
@@ -1,0 +1,56 @@
+#version 130
+
+#camera 2D
+
+#buffer RGBA32F
+
+#vertex
+
+out vec2 coord;
+out vec2 viewCoord;
+
+#group Camera
+
+uniform float Zoom; slider[1e-4,1,1e16] NotLockable
+uniform vec2 pixelSize;
+
+void main(void)
+{
+  float ar = float(pixelSize.y / pixelSize.x);
+  coord = ((gl_ProjectionMatrix * gl_Vertex).xy * vec2(ar, 1.0)) / Zoom;
+  viewCoord = gl_Vertex.xy;
+  gl_Position =  gl_Vertex;
+}
+
+#endvertex
+
+in vec2 coord;
+in vec2 viewCoord;
+
+out vec4 fragColor;
+
+uniform vec2 Center; slider[(-100,-100),(0,0),(100,100)] NotLockable
+
+uniform sampler2D backbuffer;
+
+vec3 color(vec2 p)
+{
+  int x = int(floor(16777216.0 * p.x)) & 0xFFFFFF;
+  int y = int(floor(16777216.0 * p.y)) & 0xFFFFFF;
+  int u = x ^ y;
+  float g = float(u) / 16777216.0;
+  return vec3(g);
+}
+
+void main()
+{
+  vec2 p = coord;
+  vec4 next = vec4(color(p + vec2(Center)), 1.0);
+  vec4 prev = texture(backbuffer, vec2(viewCoord + vec2(1.0)) * 0.5);
+  if (! (next == next)) // NaN check
+  {
+    next = vec4(0.0);
+  }
+  fragColor = vec4(prev + vec4(next.xyz * next.w, next.w));
+}
+

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -219,7 +219,7 @@ void DisplayWidget::setFragmentShader(FragmentSource fs)
 
 }
 
-void DisplayWidget::requireRedraw(bool clear)
+void DisplayWidget::requireRedraw(bool clear, bool bufferShaderOnly)
 {
     if (disableRedraw) {
         return;
@@ -227,6 +227,8 @@ void DisplayWidget::requireRedraw(bool clear)
 
     if ( clear ) {
         clearBackBuffer();
+        pendingRedraws = 1;
+    } else if ( bufferShaderOnly ) {
         pendingRedraws = 1;
     } else {
         subframeCounter = 0;
@@ -243,7 +245,7 @@ void DisplayWidget::uniformsHasChanged( bool bufferShaderOnly )
     }
   }
 
-  requireRedraw ( bufferShaderOnly ? false : clearOnChange );
+  requireRedraw ( bufferShaderOnly ? false : clearOnChange, bufferShaderOnly );
 }
 
 /// /* Texture mapping */

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -233,7 +233,7 @@ void DisplayWidget::requireRedraw(bool clear)
     }
 }
 
-void DisplayWidget::uniformsHasChanged()
+void DisplayWidget::uniformsHasChanged( bool bufferShaderOnly )
 {
   if(fragmentSource.depthToAlpha) {
         BoolWidget *btest = dynamic_cast<BoolWidget *>(mainWindow->getVariableEditor()->getWidgetFromName("DepthToAlpha"));
@@ -243,7 +243,7 @@ void DisplayWidget::uniformsHasChanged()
     }
   }
 
-  requireRedraw ( clearOnChange );
+  requireRedraw ( bufferShaderOnly ? false : clearOnChange );
 }
 
 /// /* Texture mapping */
@@ -1499,8 +1499,8 @@ void DisplayWidget::setShaderUniforms(QOpenGLShaderProgram *shaderProg)
 {
 
     // this should speed things up a little because we are only setting uniforms on
-    // the first subframe of the first tile
-    if (subframeCounter > 1) {
+    // the first subframe (except for buffer shader, FIXME hack) of the first tile
+    if (subframeCounter > 1 && shaderProg != bufferShaderProgram) {
         return;
     }
     // same for tiles

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -831,7 +831,10 @@ void DisplayWidget::initFragmentTextures()
         bool loaded = false;
         if(!texturePath.isEmpty()) {
 
-            int l = shaderProgram->uniformLocation ( textureUniformName );
+            int l = -1;
+            if (shaderProgram) {
+                l = shaderProgram->uniformLocation ( textureUniformName );
+            }
 
             if ( l != -1 ) { // found named texture in shader program
 

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
@@ -190,7 +190,7 @@ public:
         maxSubFrames = i;
     }
 
-    void uniformsHasChanged();
+    void uniformsHasChanged( bool bufferShaderOnly );
     void setClearOnChange ( bool v )
     {
         clearOnChange = v;

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
@@ -264,7 +264,7 @@ public slots:
     }
     int isPending()
     {
-        return pendingRedraws;
+        return pendingRedraws || pendingBufferShaderRedraws;
     }
     void setHasKeyFrames ( bool yn )
     {
@@ -294,7 +294,7 @@ public slots:
 
 protected:
     void drawFragmentProgram ( int w,int h, bool toBuffer );
-    void drawToFrameBufferObject ( QOpenGLFramebufferObject* buffer, bool drawLast );
+    void drawToFrameBufferObject ( QOpenGLFramebufferObject* buffer, bool drawLast, bool doMain = true );
 /// BEGIN 3DTexture
 //       void draw3DTexture();
 /// END 3DTexture
@@ -362,6 +362,7 @@ private:
     void setupBufferShaderVars(int w, int h);
 
     int pendingRedraws; // the number of times we must redraw
+    int pendingBufferShaderRedraws;
     QColor backgroundColor;
 
     QMenu* contextMenu;

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
@@ -118,7 +118,7 @@ public:
 
     /// Use this whenever a redraw is required.
     /// Calling this function multiple times will still only result in one redraw
-    void requireRedraw ( bool clear );
+    void requireRedraw ( bool clear, bool bufferShaderOnly = false );
     void updateRefreshRate();
     void setState ( DrawingState state );
     DrawingState getState()

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
@@ -2615,6 +2615,7 @@ bool MainWindow::initializeFragment()
         }
         editorDockWidget->setHidden( variableEditor->getWidgetCount() + variableEditor2->getWidgetCount() == 0 );
         variableEditor->updateCamera(engine->getCameraControl());
+        variableEditor2->setPresets(*variableEditor);
         engine->requireRedraw(true);
         engine->resetTime();
 

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
@@ -2648,8 +2648,16 @@ void MainWindow::hideUnusedVariableWidgets()
         // find a widget in the variable editor
         auto *vw = variableEditor->findChild<VariableWidget *>(wnames.at(i));
         if (vw != nullptr) {
-                /// get the uniform location from the shader
-                int uloc = vw->uniformLocation(engine->getShader());
+            /// get the uniform location from the shader
+            int uloc = vw->uniformLocation(engine->getShader());
+            // FIXME support old-style specifications of BufferShader widges in Main shader
+            // ticket: <https://github.com/3Dickulus/FragM/issues/56>
+            if (uloc == -1) {
+                uloc = vw->uniformLocation(engine->getBufferShader());
+                if (uloc != -1) {
+                    WARNING("Widget for " + wnames.at(i) + " should be specified in buffer shader!");
+                }
+            }
             /// locked widgets are transformed into const or #define so don't show up as uniforms
             /// AutoFocus is a dummy so does not exist inside shader program
             if(uloc == -1 &&

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
@@ -1327,7 +1327,7 @@ retry:
 
             QString prepend = firstLine + tr("// Output generated from file: ") + file + "\n";
             prepend += tr("// Created: ") + QDateTime::currentDateTime().toString() + "\n";
-            QString append = "\n\n#preset Default\n" + variableEditor->getSettings() + variableEditor2->getSettings() + "\n";
+            QString append = "\n\n#preset Default\n" + getSettings() + "\n";
 
             append += "#endpreset\n\n";
 
@@ -1710,7 +1710,7 @@ retry:
                 qd->show();
 
             } else if (!exrMode) {
-              finalImage.setText("frAg", variableEditor->getSettings() + variableEditor2->getSettings() );
+              finalImage.setText("frAg", getSettings() );
               imageSaved=finalImage.save(name);
             }
 
@@ -1755,7 +1755,7 @@ void MainWindow::savePreview()
             auto *label = qd->findChild<QLabel *>("previewImage");
             if (label != nullptr) {
                 QImage img = label->pixmap()->toImage();
-                img.setText("frAg", variableEditor->getSettings() + variableEditor2->getSettings());
+                img.setText("frAg", getSettings());
                 img.save(fn);
                 qd->close();
                 INFO(tr("Saved file : ") + fn);
@@ -1802,7 +1802,7 @@ void MainWindow::saveParameters(const QString fileName)
     }
 
     QTextStream out(&file);
-    out << variableEditor->getSettings() << variableEditor2->getSettings();
+    out << getSettings();
     INFO(tr("Settings saved to file"));
 }
 
@@ -2842,7 +2842,7 @@ Up = -0.1207781,0.8478234,0.5163409\r\n\
     if (loadingSucceded) {
         tabInfo.append(TabInfo(displayName, textEdit, false, true));
         setRecentFile(filename);
-        textEdit->saveSettings( variableEditor->getSettings() + variableEditor2->getSettings() );
+        textEdit->saveSettings( getSettings() );
 
     } else {
         tabInfo.append(TabInfo(displayName, textEdit, true));
@@ -2878,7 +2878,7 @@ void MainWindow::tabChanged(int index)
 
     TextEdit *te = getTextEdit();
 
-    te->saveSettings( variableEditor->getSettings() + variableEditor2->getSettings() );
+    te->saveSettings( getSettings() );
 
     TabInfo ti = tabInfo[index];
     QString tabTitle = QString("%1%3").arg(strippedName(ti.filename)).arg(ti.unsaved ? "*" : "");
@@ -3064,7 +3064,7 @@ void MainWindow::saveImage(QImage image)
         return;
     }
 
-    image.setText("frAg", variableEditor->getSettings() + variableEditor2->getSettings());
+    image.setText("frAg", getSettings());
 
     bool succes = image.save(filename);
     if (succes) {

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
@@ -2652,7 +2652,7 @@ void MainWindow::hideUnusedVariableWidgets()
             int uloc = vw->uniformLocation(engine->getShader());
             // FIXME support old-style specifications of BufferShader widges in Main shader
             // ticket: <https://github.com/3Dickulus/FragM/issues/56>
-            if (uloc == -1) {
+            if (uloc == -1 && engine->getBufferShader() != nullptr) {
                 uloc = vw->uniformLocation(engine->getBufferShader());
                 if (uloc != -1) {
                     WARNING("Widget for " + wnames.at(i) + " should be specified in buffer shader!");
@@ -2673,25 +2673,27 @@ void MainWindow::hideUnusedVariableWidgets()
     }
 
     /// hide unused widgets unless the default state is locked
-    wnames = variableEditor2->getWidgetNames();
-    for (int i = 0; i < wnames.count(); i++) {
-        // find a widget in the variable editor
-        auto *vw = variableEditor2->findChild<VariableWidget *>(wnames.at(i));
-        if (vw != nullptr) {
-                /// get the uniform location from the buffer shader
-                int uloc = vw->uniformLocation(engine->getBufferShader());
-            /// locked widgets are transformed into const or #define so don't show up as uniforms
-            /// AutoFocus is a dummy so does not exist inside shader program
-            if(uloc == -1 &&
-                    !(vw->getLockType() == Parser::Locked ||
-                    vw->getDefaultLockType() == Parser::AlwaysLocked ||
-                    vw->getDefaultLockType() == Parser::NotLockable) &&
-                    !wnames.at(i).contains("AutoFocus")  )  {
-                vw->hide();
-            } else {
-                vw->show();
-            }
-        }
+    if (engine->getBufferShader() != nullptr) {
+      wnames = variableEditor2->getWidgetNames();
+      for (int i = 0; i < wnames.count(); i++) {
+          // find a widget in the variable editor
+          auto *vw = variableEditor2->findChild<VariableWidget *>(wnames.at(i));
+          if (vw != nullptr) {
+              /// get the uniform location from the buffer shader
+              int uloc = vw->uniformLocation(engine->getBufferShader());
+              /// locked widgets are transformed into const or #define so don't show up as uniforms
+              /// AutoFocus is a dummy so does not exist inside shader program
+              if(uloc == -1 &&
+                      !(vw->getLockType() == Parser::Locked ||
+                      vw->getDefaultLockType() == Parser::AlwaysLocked ||
+                      vw->getDefaultLockType() == Parser::NotLockable) &&
+                      !wnames.at(i).contains("AutoFocus")  )  {
+                  vw->hide();
+              } else {
+                  vw->show();
+              }
+          }
+      }
     }
 }
 

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
@@ -2673,27 +2673,30 @@ void MainWindow::hideUnusedVariableWidgets()
     }
 
     /// hide unused widgets unless the default state is locked
-    if (engine->getBufferShader() != nullptr) {
-      wnames = variableEditor2->getWidgetNames();
-      for (int i = 0; i < wnames.count(); i++) {
-          // find a widget in the variable editor
-          auto *vw = variableEditor2->findChild<VariableWidget *>(wnames.at(i));
-          if (vw != nullptr) {
-              /// get the uniform location from the buffer shader
-              int uloc = vw->uniformLocation(engine->getBufferShader());
-              /// locked widgets are transformed into const or #define so don't show up as uniforms
-              /// AutoFocus is a dummy so does not exist inside shader program
-              if(uloc == -1 &&
-                      !(vw->getLockType() == Parser::Locked ||
-                      vw->getDefaultLockType() == Parser::AlwaysLocked ||
-                      vw->getDefaultLockType() == Parser::NotLockable) &&
-                      !wnames.at(i).contains("AutoFocus")  )  {
-                  vw->hide();
-              } else {
-                  vw->show();
-              }
-          }
-      }
+    wnames = variableEditor2->getWidgetNames();
+    for (int i = 0; i < wnames.count(); i++) {
+        // find a widget in the variable editor
+        auto *vw = variableEditor2->findChild<VariableWidget *>(wnames.at(i));
+        if (vw != nullptr) {
+            if (engine->getBufferShader() != nullptr) {
+                /// get the uniform location from the buffer shader
+                int uloc = vw->uniformLocation(engine->getBufferShader());
+                /// locked widgets are transformed into const or #define so don't show up as uniforms
+                /// AutoFocus is a dummy so does not exist inside shader program
+                if(uloc == -1 &&
+                        !(vw->getLockType() == Parser::Locked ||
+                        vw->getDefaultLockType() == Parser::AlwaysLocked ||
+                        vw->getDefaultLockType() == Parser::NotLockable) &&
+                        !wnames.at(i).contains("AutoFocus")  )  {
+                    vw->hide();
+                } else {
+                    vw->show();
+                }
+            } else {
+                // hide all widgets if there is no BufferShader
+                vw->hide();
+            }
+        }
     }
 }
 

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
@@ -193,7 +193,7 @@ public:
     QString getCameraSettings();
     QString getSettings()
     {
-        return variableEditor->getSettings() + variableEditor2->getSettings();
+        return variableEditor->getSettings() + "\n" + variableEditor2->getSettings();
     };
     void disableAllExcept ( QWidget *w );
     void setSplashWidgetTimeout ( QSplashScreen *w );

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
@@ -176,7 +176,9 @@ public:
 
     QVector<VariableWidget *> getUserUniforms()
     {
-        return variableEditor->getUserUniforms();
+        QVector<VariableWidget *> v = variableEditor->getUserUniforms();
+        v.append(variableEditor2->getUserUniforms());
+        return v;
     };
 
     DisplayWidget *getEngine()
@@ -191,7 +193,7 @@ public:
     QString getCameraSettings();
     QString getSettings()
     {
-        return variableEditor->getSettings();
+        return variableEditor->getSettings() + variableEditor2->getSettings();
     };
     void disableAllExcept ( QWidget *w );
     void setSplashWidgetTimeout ( QSplashScreen *w );
@@ -222,6 +224,10 @@ public:
     VariableEditor *getVariableEditor()
     {
         return variableEditor;
+    }
+    VariableEditor *getVariableEditor2()
+    {
+        return variableEditor2;
     }
     double getTimeMax()
     {
@@ -254,6 +260,7 @@ public:
     void setDefault()
     {
         variableEditor->setDefault();
+        variableEditor2->setDefault();
     };
     bool wantSplineOcc()
     {
@@ -278,6 +285,7 @@ public:
         verbose = v;
         getEngine()->setVerbose ( v );
         getVariableEditor()->setVerbose ( v );
+        getVariableEditor2()->setVerbose ( v );
     };
 
     QString langID;
@@ -300,29 +308,30 @@ public slots:
     void setParameter ( QString settings )
     {
         variableEditor->setSettings ( settings );
+        variableEditor2->setSettings ( settings );
     };
     void setParameter ( QString setting, bool b )
     {
-        variableEditor->setSettings (QString ( "%1 = %2\n" ).arg ( setting ).arg ( b ? "true" : "false" ) );
+        setParameter (QString ( "%1 = %2\n" ).arg ( setting ).arg ( b ? "true" : "false" ) );
     };
     void setParameter ( QString setting, int v )
     {
-        variableEditor->setSettings ( QString ( "%1 = %2\n" ).arg ( setting ).arg ( v ) );
+        setParameter ( QString ( "%1 = %2\n" ).arg ( setting ).arg ( v ) );
     };
     void setParameter ( QString setting, double v )
     {
-        variableEditor->setSettings (QString ( "%1 = %2\n" ).arg ( setting ).arg ( v, 0, 'g', DDEC ) );
+        setParameter (QString ( "%1 = %2\n" ).arg ( setting ).arg ( v, 0, 'g', DDEC ) );
     };
     void setParameter ( QString setting, double x, double y )
     {
-        variableEditor->setSettings ( QString ( "%1 = %2,%3\n" )
+        setParameter ( QString ( "%1 = %2,%3\n" )
                                       .arg ( setting )
                                       .arg ( x, 0, 'g', DDEC )
                                       .arg ( y, 0, 'g', DDEC ) );
     };
     void setParameter ( QString setting, double x, double y, double z )
     {
-        variableEditor->setSettings ( QString ( "%1 = %2,%3,%4\n" )
+        setParameter ( QString ( "%1 = %2,%3,%4\n" )
                                       .arg ( setting )
                                       .arg ( x, 0, 'g', DDEC )
                                       .arg ( y, 0, 'g', DDEC )
@@ -330,7 +339,7 @@ public slots:
     };
     void setParameter ( QString setting, double x, double y, double z, double w )
     {
-        variableEditor->setSettings ( QString ( "%1 = %2,%3,%4,%5\n" )
+        setParameter ( QString ( "%1 = %2,%3,%4,%5\n" )
                                       .arg ( setting )
                                       .arg ( x, 0, 'g', DDEC )
                                       .arg ( y, 0, 'g', DDEC )
@@ -441,6 +450,7 @@ public slots:
     bool applyPresetByName ( QString n )
     {
         rebuildRequired = variableEditor->setPreset ( n );
+        rebuildRequired |= variableEditor2->setPreset ( n );
         rebuildRequired |= initializeFragment();
         rebuildRequired |= initializeFragment();
         processGuiEvents();
@@ -529,6 +539,7 @@ private slots:
     void veDockChanged ( bool t )
     {
         variableEditor->dockChanged ( t );
+        variableEditor2->dockChanged ( t );
     }; // 05/22/17 Sabine ;)
     void clearKeyFrameControl();
     void bufferSpinBoxChanged ( int value );
@@ -549,6 +560,7 @@ private slots:
     void preferences();
     void insertText();
     void variablesChanged ( bool lockedChanged );
+    void variablesChanged2 ( bool lockedChanged ); // BufferShader
     void cut();
     void copy();
     void paste();
@@ -579,7 +591,8 @@ private slots:
     void setEasing()
     {
         variableEditor->setEasingCurve();
-        tabInfo[tabBar->currentIndex()].unsaved = ( variableEditor->hasEasing() ) ? true : tabInfo[tabBar->currentIndex()].unsaved;
+        variableEditor2->setEasingCurve();
+        tabInfo[tabBar->currentIndex()].unsaved = ( variableEditor->hasEasing() || variableEditor2->hasEasing() ) ? true : tabInfo[tabBar->currentIndex()].unsaved;
     }
 
     void timeMaxChanged ( int value );
@@ -689,6 +702,7 @@ private:
     QVector<TabInfo> tabInfo;
     QVBoxLayout *frameMainWindow;
     VariableEditor *variableEditor;
+    VariableEditor *variableEditor2; // BufferShader
     QDockWidget *editorDockWidget;
     QVector<QAction *> recentFileActions;
     QAction *recentFileSeparator;

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
@@ -455,6 +455,13 @@ public slots:
         rebuildRequired |= initializeFragment();
         processGuiEvents();
         processGuiEvents();
+        if (! rebuildRequired) {
+            /// this bit of fudge sets the current time to keyframe time
+            QRegExp rx = QRegExp("(KeyFrame\\.\\d\\d\\d)");
+            if(rx.indexIn(n) != -1)  { /// found a keyframe
+                setTimeSliderValue(variableEditor->getCurrentKeyFrame() * ((getTimeMax() * renderFPS) / (variableEditor->getKeyFrameCount() - 1)));
+            }
+        }
         return !rebuildRequired; // if rebuild is required applying the preset failed
     };
 

--- a/Fragmentarium-Source/Fragmentarium/GUI/VariableEditor.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/VariableEditor.cpp
@@ -158,6 +158,11 @@ void VariableEditor::setPresets(QMap<QString, QString> presets)
     }
 }
 
+void VariableEditor::setPresets(const VariableEditor &other)
+{
+    setPresets(other.presets);
+}
+
 bool VariableEditor::setDefault()
 {
     if (!(QSettings().value("autorun", true).toBool())) {
@@ -174,14 +179,7 @@ bool VariableEditor::setDefault()
 
 bool VariableEditor::applyPreset()
 {
-    QString presetName = presetComboBox->currentText();
-    QString preset = presets[presetName];
-    /// this bit of fudge sets the current time to keyframe time
-    QRegExp rx = QRegExp("(KeyFrame\\.\\d\\d\\d)");
-    if(rx.indexIn(presetName) != -1)  { /// found a keyframe
-        mainWindow->setTimeSliderValue(getCurrentKeyFrame() * ((mainWindow->getTimeMax() * mainWindow->renderFPS) / (getKeyFrameCount() - 1)));
-    }
-    return setSettings(preset);
+    return mainWindow->applyPresetByName(presetComboBox->currentText());
 }
 
 void VariableEditor::resetUniforms(bool clear)
@@ -1053,7 +1051,7 @@ bool VariableEditor::setPreset(QString p)
 {
     int item = presetComboBox->findText(p, Qt::MatchFixedString);
     presetComboBox->setCurrentIndex(item);
-    return applyPreset();
+    return setSettings(getPresetByName(p).join("\n"));
     /// this bit of fudge sets the current time to keyframe time
 //     if(hasKeyFrames())
     //         mainWindow->setTimeSliderValue( getCurrentKeyFrame() *

--- a/Fragmentarium-Source/Fragmentarium/GUI/VariableEditor.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/VariableEditor.h
@@ -47,6 +47,7 @@ public:
     void createGroup(QString g);
     VariableWidget* getWidgetFromName(QString name);
     void setPresets(QMap<QString, QString> presets);
+    void setPresets(const VariableEditor &other);
     ComboSlider *getCurrentComboSlider()
     {
         return currentComboSlider;


### PR DESCRIPTION
Adds a separate VariableEditor for BufferShader widgets that allows (eg) Post uniforms like Exposure or Contrast etc to be modified without losing accumulated subframes.

Remaining small issues:
- GUI layout is not optimal (BufferShader VariableEditor takes up equal space to Main VariableEditor)
- rewinding stopped animation displays blank image (0 subframes rendered)
- all the frags need to be updated to move BufferShader widgets to their proper place to take advantage of the really-Post-rendering behaviour (this will make them incompatible with older FragM, so maybe a FragM version bump is a good idea?) - meanwhile warnings are printed about what needs moving (still works, just not optimally)