### PR TITLE
[feature] BufferShader GUI (try 2)

### DIFF
--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -2240,7 +2240,10 @@ void DisplayWidget::timerSignal()
         cameraControl->updateState();
     }
 
-    if (isPending()) {
+    if (pendingRedraws != 0) {
+        if (buttonDown) {
+            pendingRedraws = 1;
+        }
         update();
     } else if ( continuous ) {
         if ( drawingState == Progressive &&

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -2252,9 +2252,6 @@ void DisplayWidget::timerSignal()
     }
 
     if (isPending()) {
-        if (buttonDown) {
-            pendingRedraws = 0;
-        }
         update();
     } else if ( continuous ) {
         if ( drawingState == Progressive &&

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -1533,7 +1533,8 @@ void DisplayWidget::resetUniformProvenance()
     }
     foreach (VariableWidget *w, vw) {
         if (w->getProvenance() == FromBufferShader) {
-            w->setStyleSheet("QLabel { border-style: outset; border-width: 2px; border-color: beige; }");
+            QColor c = qApp->palette().color(QPalette::Inactive, QPalette::Mid);
+            w->setStyleSheet("QLabel { border-style: outset; border-width: 2px; border-color: " + c.name() + "; }");
         } else {
             w->setStyleSheet("QLabel { border: none; }");
         }

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -1531,6 +1531,13 @@ void DisplayWidget::resetUniformProvenance()
             }
         }
     }
+    foreach (VariableWidget *w, vw) {
+        if (w->getProvenance() == FromBufferShader) {
+            w->setStyleSheet("QLabel { border-style: outset; border-width: 2px; border-color: beige; }");
+        } else {
+            w->setStyleSheet("QLabel { border: none; }");
+        }
+    }
 }
 
 void DisplayWidget::setShaderUniforms(QOpenGLShaderProgram *shaderProg)

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -70,7 +70,6 @@ DisplayWidget::DisplayWidget ( MainWindow* mainWin, QWidget* parent )
     disabled = false;
     updatePerspective();
     pendingRedraws = 0;
-    pendingBufferShaderRedraws = 0;
     setMouseTracking ( true );
     backgroundColor = QColor ( 30,30,30 );
     contextMenu = nullptr;
@@ -216,6 +215,7 @@ void DisplayWidget::setFragmentShader(FragmentSource fs)
         initBufferShader();
     }
 
+    resetUniformProvenance();
 }
 
 void DisplayWidget::requireRedraw(bool clear, bool bufferShaderOnly)
@@ -227,15 +227,14 @@ void DisplayWidget::requireRedraw(bool clear, bool bufferShaderOnly)
     if ( clear ) {
         clearBackBuffer();
         pendingRedraws = 1;
-        pendingBufferShaderRedraws = 1;
     } else if ( bufferShaderOnly ) {
-        pendingBufferShaderRedraws = 1;
+        // nop
     } else {
         subframeCounter = 0;
     }
 }
 
-void DisplayWidget::uniformsHasChanged()
+void DisplayWidget::uniformsHasChanged(Provenance provenance)
 {
   if(fragmentSource.depthToAlpha) {
         BoolWidget *btest = dynamic_cast<BoolWidget *>(mainWindow->getVariableEditor()->getWidgetFromName("DepthToAlpha"));
@@ -244,7 +243,8 @@ void DisplayWidget::uniformsHasChanged()
       depthToAlpha = btest->isChecked();
     }
   }
-
+  bufferUniformsHaveChanged |= !!(provenance & FromBufferShader);
+  bool bufferShaderOnly = provenance == FromBufferShader;
   requireRedraw ( bufferShaderOnly ? false : clearOnChange, bufferShaderOnly );
 }
 
@@ -1508,18 +1508,45 @@ void DisplayWidget::setDoubleType(GLuint programID, GLenum type, QString uniform
     }
 }
 
+void DisplayWidget::resetUniformProvenance()
+{
+    QVector<VariableWidget*> vw = mainWindow->getUserUniforms();
+    foreach (VariableWidget *w, vw) {
+        w->setProvenance(FromUnknown);
+    }
+    QOpenGLShaderProgram *programs[2] = { shaderProgram, bufferShaderProgram };
+    Provenance provenances[2] = { FromMainShader, FromBufferShader };
+    for (int k = 0; k < 2; ++k) {
+        QOpenGLShaderProgram *shaderProg = programs[k];
+        Provenance provenance = provenances[k];
+        if (shaderProg == nullptr) continue;
+        GLuint programID = shaderProg->programId();
+        if (programID == 0) continue;
+        GLint count = 0;
+        // this only returns uniforms that have not been optimized out
+        glGetProgramiv(programID, GL_ACTIVE_UNIFORMS, &count);
+        for (int i = 0; i < count; i++) {
+            GLsizei bufSize = 256;
+            GLsizei length;
+            GLint size;
+            GLenum type;
+            GLchar name[bufSize];
+            glGetActiveUniform(programID, i, bufSize, &length, &size, &type, name);
+            QString uniformName = (char *)name;
+            // FIXME this is quadratic: O(number of active uniforms * number of widgets declared)
+            // FIXME could go to n log n by sorting each by name and zip ascending?
+            foreach (VariableWidget *w, vw) {
+                if (uniformName == w->getName()) {
+                    w->addProvenance(provenance);
+                    break; // can't have more than one uniform with the same name
+                }
+            }
+        }
+    }
+}
+
 void DisplayWidget::setShaderUniforms(QOpenGLShaderProgram *shaderProg)
 {
-
-    // this should speed things up a little because we are only setting uniforms on
-    // the first subframe of the first tile
-    if (subframeCounter > 1) {
-        return;
-    }
-    // same for tiles
-    if (tilesCount > 1) {
-        return;
-    }
 
     GLuint programID = shaderProg->programId();
 
@@ -1722,7 +1749,12 @@ void DisplayWidget::drawFragmentProgram(int w, int h, bool toBuffer)
     setupShaderVars(w, h);
 
     // Setup User Uniforms
-    setShaderUniforms(shaderProgram);
+
+    // this should speed things up a little because we are only setting uniforms on
+    // the first subframe of the first tile
+    if (subframeCounter <= 1 && tilesCount <= 1) {
+        setShaderUniforms(shaderProgram);
+    }
 
     // save current state
     glPushAttrib ( GL_ALL_ATTRIB_BITS );
@@ -1818,7 +1850,10 @@ void DisplayWidget::setupBufferShaderVars(int w, int h)
             WARNING(tr("No front buffer sampler found in buffer shader. This doesn't make sense."));
         }
         // Setup User Uniforms
-        setShaderUniforms ( bufferShaderProgram );
+        if (bufferUniformsHaveChanged) {
+            setShaderUniforms ( bufferShaderProgram );
+            bufferUniformsHaveChanged = false;
+        }
 }
 
 void DisplayWidget::drawToFrameBufferObject(QOpenGLFramebufferObject *buffer, bool drawLast, bool doMain)
@@ -2130,9 +2165,6 @@ void DisplayWidget::paintGL()
     if (pendingRedraws > 0) {
         pendingRedraws--;
     }
-    if (pendingBufferShaderRedraws > 0) {
-        pendingBufferShaderRedraws--;
-    }
 
     if (disabled || shaderProgram == nullptr) {
         glClearColor(backgroundColor.redF(), backgroundColor.greenF(), backgroundColor.blueF(), backgroundColor.alphaF());
@@ -2234,7 +2266,6 @@ void DisplayWidget::timerSignal()
 
             // render
             pendingRedraws = 1;
-            pendingBufferShaderRedraws = 1;
             update();
             QTime cur = QTime::currentTime();
             long ms = t.msecsTo ( cur );

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -70,6 +70,7 @@ DisplayWidget::DisplayWidget ( MainWindow* mainWin, QWidget* parent )
     disabled = false;
     updatePerspective();
     pendingRedraws = 0;
+    pendingBufferShaderRedraws = 0;
     setMouseTracking ( true );
     backgroundColor = QColor ( 30,30,30 );
     contextMenu = nullptr;
@@ -226,8 +227,9 @@ void DisplayWidget::requireRedraw(bool clear, bool bufferShaderOnly)
     if ( clear ) {
         clearBackBuffer();
         pendingRedraws = 1;
+        pendingBufferShaderRedraws = 1;
     } else if ( bufferShaderOnly ) {
-        pendingRedraws = 1;
+        pendingBufferShaderRedraws = 1;
     } else {
         subframeCounter = 0;
     }
@@ -1819,7 +1821,7 @@ void DisplayWidget::setupBufferShaderVars(int w, int h)
         setShaderUniforms ( bufferShaderProgram );
 }
 
-void DisplayWidget::drawToFrameBufferObject(QOpenGLFramebufferObject *buffer, bool drawLast)
+void DisplayWidget::drawToFrameBufferObject(QOpenGLFramebufferObject *buffer, bool drawLast, bool doMain)
 {
 
     if (!this->isValid() || !FBOcheck()) {
@@ -1828,7 +1830,7 @@ void DisplayWidget::drawToFrameBufferObject(QOpenGLFramebufferObject *buffer, bo
 
     QSize s = backBuffer->size();
 
-    if ( !drawLast ) {
+    if ( !drawLast && doMain ) {
         for ( int i = 0; i <= iterationsBetweenRedraws; i++ ) {
             if (backBuffer != nullptr) {
                 // swap backbuffer
@@ -2124,8 +2126,12 @@ void DisplayWidget::paintGL()
         return;
     }
 
+    bool doMain = pendingRedraws > 0;
     if (pendingRedraws > 0) {
         pendingRedraws--;
+    }
+    if (pendingBufferShaderRedraws > 0) {
+        pendingBufferShaderRedraws--;
     }
 
     if (disabled || shaderProgram == nullptr) {
@@ -2167,7 +2173,7 @@ void DisplayWidget::paintGL()
         }
     }
 
-    drawToFrameBufferObject( nullptr, (subframeCounter >= maxSubFrames && maxSubFrames > 0));
+    drawToFrameBufferObject( nullptr, (subframeCounter >= maxSubFrames && maxSubFrames > 0), doMain );
 
 }
 
@@ -2210,7 +2216,7 @@ void DisplayWidget::timerSignal()
         cameraControl->updateState();
     }
 
-    if (pendingRedraws != 0) {
+    if (isPending()) {
         if (buttonDown) {
             pendingRedraws = 0;
         }
@@ -2227,6 +2233,8 @@ void DisplayWidget::timerSignal()
             QTime t = QTime::currentTime();
 
             // render
+            pendingRedraws = 1;
+            pendingBufferShaderRedraws = 1;
             update();
             QTime cur = QTime::currentTime();
             long ms = t.msecsTo ( cur );

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -217,7 +217,7 @@ void DisplayWidget::setFragmentShader(FragmentSource fs)
 
 }
 
-void DisplayWidget::requireRedraw(bool clear)
+void DisplayWidget::requireRedraw(bool clear, bool bufferShaderOnly)
 {
     if (disableRedraw) {
         return;
@@ -225,6 +225,8 @@ void DisplayWidget::requireRedraw(bool clear)
 
     if ( clear ) {
         clearBackBuffer();
+        pendingRedraws = 1;
+    } else if ( bufferShaderOnly ) {
         pendingRedraws = 1;
     } else {
         subframeCounter = 0;
@@ -241,7 +243,7 @@ void DisplayWidget::uniformsHasChanged()
     }
   }
 
-  requireRedraw ( clearOnChange );
+  requireRedraw ( bufferShaderOnly ? false : clearOnChange, bufferShaderOnly );
 }
 
 /// /* Texture mapping */

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -229,6 +229,7 @@ void DisplayWidget::requireRedraw(bool clear, bool bufferShaderOnly)
     if ( clear ) {
         clearBackBuffer();
         pendingRedraws = 1;
+        bufferUniformsHaveChanged = true; // fixed bad image after rebuild
     } else if ( bufferShaderOnly ) {
         // nop
     } else {

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -231,8 +231,8 @@ void DisplayWidget::requireRedraw(bool clear, bool bufferShaderOnly)
         pendingRedraws = 1;
         bufferUniformsHaveChanged = true; // fixed bad image after rebuild
     } else if ( bufferShaderOnly ) {
-        // nop
-    } else {
+        pendingRedraws = 1;
+    } else if ( clearOnChange ) {
         subframeCounter = 0;
     }
 }

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
@@ -190,7 +190,7 @@ public:
         maxSubFrames = i;
     }
 
-    void uniformsHasChanged();
+    void uniformsHasChanged(Provenance provenance);
     void setClearOnChange ( bool v )
     {
         clearOnChange = v;
@@ -262,9 +262,9 @@ public slots:
     {
         return renderFPS;
     }
-    int isPending()
+    bool isPending()
     {
-        return pendingRedraws || pendingBufferShaderRedraws;
+        return pendingRedraws || bufferUniformsHaveChanged;
     }
     void setHasKeyFrames ( bool yn )
     {
@@ -356,13 +356,14 @@ private:
 
     void setDoubleType(GLuint programID, GLenum type, QString uniformName, QString uniformValue, bool &foundDouble, QString &tp);
 
+    void resetUniformProvenance();
     void setupShaderVars(int w, int h);
     void draw3DHints();
     bool FBOcheck();
     void setupBufferShaderVars(int w, int h);
 
     int pendingRedraws; // the number of times we must redraw
-    int pendingBufferShaderRedraws;
+    bool bufferUniformsHaveChanged;
     QColor backgroundColor;
 
     QMenu* contextMenu;

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
@@ -264,7 +264,7 @@ public slots:
     }
     int isPending()
     {
-        return pendingRedraws;
+        return pendingRedraws || pendingBufferShaderRedraws;
     }
     void setHasKeyFrames ( bool yn )
     {
@@ -294,7 +294,7 @@ public slots:
 
 protected:
     void drawFragmentProgram ( int w,int h, bool toBuffer );
-    void drawToFrameBufferObject ( QOpenGLFramebufferObject* buffer, bool drawLast );
+    void drawToFrameBufferObject ( QOpenGLFramebufferObject* buffer, bool drawLast, bool doMain = true );
 /// BEGIN 3DTexture
 //       void draw3DTexture();
 /// END 3DTexture
@@ -362,6 +362,7 @@ private:
     void setupBufferShaderVars(int w, int h);
 
     int pendingRedraws; // the number of times we must redraw
+    int pendingBufferShaderRedraws;
     QColor backgroundColor;
 
     QMenu* contextMenu;

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
@@ -118,7 +118,7 @@ public:
 
     /// Use this whenever a redraw is required.
     /// Calling this function multiple times will still only result in one redraw
-    void requireRedraw ( bool clear );
+    void requireRedraw ( bool clear, bool bufferShaderOnly = false );
     void updateRefreshRate();
     void setState ( DrawingState state );
     DrawingState getState()

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
@@ -688,7 +688,7 @@ void MainWindow::init()
     vboxLayout2->addWidget(variableEditor);
     editorDockWidget->setWidget(editorLogContents);
     addDockWidget(Qt::RightDockWidgetArea, editorDockWidget);
-    connect(variableEditor, SIGNAL(changed(bool)), this, SLOT(variablesChanged(bool)));
+    connect(variableEditor, SIGNAL(changed(bool,Provenance)), this, SLOT(variablesChanged(bool,Provenance)));
     connect(editorDockWidget, SIGNAL(topLevelChanged(bool)), this, SLOT(veDockChanged(bool))); // 05/22/17 Sabine ;)
 
     editorDockWidget->setHidden(true);
@@ -872,13 +872,13 @@ void MainWindow::showWelcomeNote()
 
 }
 
-void MainWindow::variablesChanged(bool lockedChanged)
+void MainWindow::variablesChanged(bool lockedChanged, Provenance provenance)
 {
 
     if (lockedChanged) {
         highlightBuildButton(true);
     }
-    engine->uniformsHasChanged();
+    engine->uniformsHasChanged(provenance);
 }
 
 void MainWindow::createOpenGLContextMenu()

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
@@ -545,7 +545,7 @@ private slots:
     void indent();
     void preferences();
     void insertText();
-    void variablesChanged ( bool lockedChanged );
+    void variablesChanged ( bool lockedChanged, Provenance provenance );
     void cut();
     void copy();
     void paste();

--- a/Fragmentarium-Source/Fragmentarium/GUI/VariableEditor.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/VariableEditor.h
@@ -123,7 +123,7 @@ public:
     }
 
 signals:
-    void changed(bool lockedChanged);
+    void changed(bool lockedChanged, Provenance provenance);
 
 public slots:
     void sliderDestroyed ( QObject *obj );
@@ -136,7 +136,7 @@ public slots:
     void copy();
     void copyGroup();
     void paste();
-    void childChanged(bool lockedChanged);
+    void childChanged(bool lockedChanged, Provenance provenance);
     void presetSelected(QString presetName);
     void dockChanged ( bool t )
     {

--- a/Fragmentarium-Source/Fragmentarium/GUI/VariableWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/VariableWidget.cpp
@@ -28,7 +28,7 @@ using namespace SyntopiaCore::Misc;
 using namespace Fragmentarium::Parser;
 
 VariableWidget::VariableWidget(QWidget *parent, QWidget *variableEditor, QString name)
-    : QWidget(parent), name(name), updated(false), systemVariable(false), variableEditor(variableEditor)
+    : QWidget(parent), name(name), updated(false), systemVariable(false), variableEditor(variableEditor), provenance(FromUnknown)
 {
 
     auto *vl = new QHBoxLayout(this);
@@ -51,7 +51,7 @@ VariableWidget::VariableWidget(QWidget *parent, QWidget *variableEditor, QString
 
     widget = new QWidget(this);
     vl->addWidget(widget);
-    connect(this, SIGNAL(changed(bool)), variableEditor, SLOT(childChanged(bool)));
+    connect(this, SIGNAL(changed(bool,Provenance)), variableEditor, SLOT(childChanged(bool,Provenance)));
 }
 
 bool VariableWidget::isLocked()
@@ -61,15 +61,14 @@ bool VariableWidget::isLocked()
 
 void VariableWidget::valueChanged()
 {
-
     if (lockType == Locked || lockType == AlwaysLocked ) {
         QPalette pal = palette();
         pal.setColor(backgroundRole(), Qt::yellow);
         setPalette(pal);
         setAutoFillBackground(true);
-        emit(changed(true));
+        emit(changed(true, getProvenance()));
     } else {
-        emit(changed(false));
+        emit(changed(false, getProvenance()));
     }
 }
 

--- a/Fragmentarium-Source/Fragmentarium/GUI/VariableWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/VariableWidget.h
@@ -359,6 +359,18 @@ public:
     {
         return group;
     }
+    void setProvenance(Provenance p)
+    {
+        provenance = p;
+    }
+    void addProvenance(Provenance p)
+    {
+        provenance = Provenance(provenance | p);
+    }
+    Provenance getProvenance() const
+    {
+        return provenance;
+    }
     bool isUpdated() const
     {
         return updated;
@@ -406,7 +418,7 @@ public slots:
     void valueChanged();
 
 signals:
-    void changed(bool lockedChanged);
+    void changed(bool lockedChanged, Provenance provenance);
 
 protected:
     QString toGLSL ( double d )
@@ -429,6 +441,7 @@ protected:
     bool wantDouble=false;
     QWidget* widget;
     QWidget* variableEditor;
+    Provenance provenance;
 };
 
 class SamplerWidget : public VariableWidget

--- a/Fragmentarium-Source/Fragmentarium/Parser/Preprocessor.h
+++ b/Fragmentarium-Source/Fragmentarium/Parser/Preprocessor.h
@@ -23,6 +23,8 @@ namespace Parser {
 
 using namespace SyntopiaCore::Logging;
 
+enum Provenance { FromUnknown = 0, FromMainShader = 1, FromBufferShader = 2, FromBothShaders = 3 };
+
 enum LockTypeInner { Locked, NotLocked, NotLockable, AlwaysLocked, Unknown } ;
 
 class LockType {
@@ -125,7 +127,7 @@ private:
 
 class GuiParameter {
 public:
-    GuiParameter(QString group, QString name, QString tooltip) : group(group), name(name), tooltip(tooltip) {
+    GuiParameter(QString group, QString name, QString tooltip) : lockType(Unknown), sliderType(UnknownSliderType), provenance(FromUnknown), group(group), name(name), tooltip(tooltip) {
     };
 
     QString getName() {
@@ -150,6 +152,15 @@ public:
     void setSliderType(SliderType l) {
         sliderType = l;
     }
+    Provenance getProvenance() {
+        return provenance;
+    }
+    void setProvenance(Provenance l) {
+        provenance = l;
+    }
+    void addProvenance(Provenance l) {
+        provenance = Provenance(provenance | l);
+    }
     void setIsDouble(bool v) {
         wantDouble = v;
     }
@@ -159,6 +170,7 @@ public:
 protected:
     LockType lockType;
     SliderType sliderType;
+    Provenance provenance;
     QString group;
     QString name;
     QString tooltip;


### PR DESCRIPTION
Adds and tracks Provenance (which shader(s) the widget's uniforms are active in) of changes, and merges widget specifications from the BufferShader into the main VariableEditor.

Two big advantages:
- you can optionally define widget specifications in buffer shaders (previously they were ignored); this way you don't need to copy/paste/errors between all your main frags (or their included files)
- widgets (specified in either shader) with Provenance FromBufferShader don't force resetting subframes when the are changed

Some issues:
- no visual indication of Provenance, so you can't tell before touching if you'll lose accumulated subframes
- no check yet for matching types if a uniform happens to be active in both shaders; the widget is taken from the Main shader in this case