### PR TITLE
keep all-but-last .-separated part in currentFragmentName()

### DIFF
--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
@@ -463,11 +463,12 @@ public slots:
     };
     QString currentFragmentName()
     {
-        return tabInfo[tabBar->currentIndex()]
+        QStringList parts = tabInfo[tabBar->currentIndex()]
                .filename.split ( QDir::separator() )
                .last()
-               .split ( "." )
-               .first();
+               .split ( "." );
+        parts.removeLast();
+        return parts.join ( "." );
     };
     void scriptExitProgram ( int x = 0 )
     {


### PR DESCRIPTION
There will be at least one part from split() so removeLast() is safe.

Fixes: https://github.com/3Dickulus/FragM/issues/69