### PR TITLE
[feature] bind fqScript to F6 key

### DIFF
--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QShortcut>
 #include <QAbstractScrollArea>
 #include <QCheckBox>
 #include <QComboBox>
@@ -593,6 +594,9 @@ private slots:
     QString makeImgFileName ( int timeStep, int timeSteps, QString fileName );
     void showHelpMessage ( QString title, QString mess );
     void hideUnusedVariableWidgets();
+    // slot for F6 hotkey handlers
+    void slotShortcutF6();
+    void slotShortcutShiftF6();
 
 private:
 
@@ -736,6 +740,9 @@ private:
     QMap<int, EasingInfo *> easingMap;
 
     QFileSystemWatcher *fragWatch;
+
+    QShortcut       *keyF6;           // Entity of F6 hotkey
+    QShortcut       *keyShiftF6;      // Entity of Shift+F6 hotkey
 
 };
 }

--- a/Fragmentarium-Source/fqScript/renderPresets.fqs
+++ b/Fragmentarium-Source/fqScript/renderPresets.fqs
@@ -5,7 +5,7 @@
 var width=360;
 var height=360;
 var multiplier=2; // 10=10x10=100 tiles
-var subframes=256;
+var subframes=128;
 
 // set subfolder must end with "/"
 var subFolder = "thumbs/";
@@ -54,8 +54,10 @@ function init(){
 
 function renderPreset(value) {
 
+var fname = subFolder+value+".png";
+
   // we need to adjust the filename for each preset
-  app.setOutputBaseFileName(subFolder+value+".png");
+  app.setOutputBaseFileName(fname);
 
   // if the user wants to stop rendering break before next image
   if(app.scriptRunning()) {
@@ -65,7 +67,7 @@ function renderPreset(value) {
     // render an image
     app.tileBasedRender();
     // output stats
-    print( (width)+"\t"+(height)+"\t"+(multiplier)+"\t"+((app.getTileAVG()/1000)/subframes).toFixed(9)+"\t"+(app.getTileAVG()/1000).toFixed(9)+"\t"+(app.getRenderAVG()/1000).toFixed(9) +"\t" + subFolder + value );
+    print( (width)+"\t"+(height)+"\t"+(multiplier)+"\t"+((app.getTileAVG()/1000)/subframes).toFixed(9)+"\t"+(app.getTileAVG()/1000).toFixed(9)+"\t"+(app.getRenderAVG()/1000).toFixed(9) +"\t" + fname);
   }
 
 }


### PR DESCRIPTION
Instigated by some discussion with user kosalos at fractalforums.org

* Shift+F6 opens a file dialog for selecting a .fqs script and binds it's execution to the F6 key

* F6 executes the last .fqs file saved  from the CmdScript editor or executes the file bound via Shift+F6

If you bind a script it will appear in the CmdScript editor when activated.

A good example is the renderPresets.fqs file, it will render all presets from the current fragment into a folder named thumbs (expected to exist)
You can adjust thumb size and storage location in the renderPresets.fqs script.