### PR TITLE
Languages and Autosave (#80)

### DIFF
--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
@@ -20,6 +20,7 @@
 
 #include <qfilesystemwatcher.h>
 
+#include "OutputDialog.h"
 #include "DisplayWidget.h"
 #include "Highlighter.h"
 #include "VariableEditor.h"

--- a/Fragmentarium-Source/Translations/Fragmentarium_de.ts
+++ b/Fragmentarium-Source/Translations/Fragmentarium_de.ts
@@ -34,7 +34,7 @@
 <context>
     <name>Camera2D</name>
     <message>
-        <location filename="../Fragmentarium/GUI/CameraControl.cpp" line="+474"/>
+        <location filename="../Fragmentarium/GUI/CameraControl.cpp" line="+478"/>
         <source>Camera: Click on 2D window for key focus. See Help Menu for more.</source>
         <translation>Kamera: Klicken Sie auf 2D-Fenster Schwerpunkt. Siehe Hilfe-Menü für mehr.</translation>
     </message>
@@ -49,7 +49,7 @@
         <translation>Kann Zoom-Schnittstellenwidget nicht finden</translation>
     </message>
     <message>
-        <location line="+33"/>
+        <location line="+58"/>
         <location line="+6"/>
         <location line="+6"/>
         <location line="+6"/>
@@ -60,7 +60,7 @@
 <context>
     <name>Camera3D</name>
     <message>
-        <location line="-457"/>
+        <location line="-486"/>
         <source>Could not find Eye interface widget</source>
         <translation>Kann Eye-Schnittstellenwidget nicht finden</translation>
     </message>
@@ -258,7 +258,7 @@
 <context>
     <name>Fragmentarium::GUI::ComboSlider</name>
     <message>
-        <location filename="../Fragmentarium/GUI/VariableWidget.h" line="+93"/>
+        <location filename="../Fragmentarium/GUI/VariableWidget.h" line="+104"/>
         <source>Slider Step Multiplier</source>
         <translation>Slider-Step-Multiplikator</translation>
     </message>
@@ -276,7 +276,7 @@
 <context>
     <name>Fragmentarium::GUI::DisplayWidget</name>
     <message>
-        <location filename="../Fragmentarium/GUI/DisplayWidget.cpp" line="+120"/>
+        <location filename="../Fragmentarium/GUI/DisplayWidget.cpp" line="+125"/>
         <source>Setting display update timer to %1 ms (max %2 FPS).</source>
         <translation>Display-Updatetimer wird eingestellt auf %1 ms (max %2 FPS).</translation>
     </message>
@@ -310,7 +310,7 @@ Initialisiert als GL_RGBA8</translation>
         <translation>Maximale Texturgröße: %1x%1</translation>
     </message>
     <message>
-        <location line="+133"/>
+        <location line="+138"/>
         <source>Asked gpu for %1 mip-map levels.</source>
         <translation>GPU gebeten um %1 mip-map levels.</translation>
     </message>
@@ -340,7 +340,7 @@ Initialisiert als GL_RGBA8</translation>
         <translation>Kann nicht parsen: TexParameter value: </translation>
     </message>
     <message>
-        <location line="+158"/>
+        <location line="+176"/>
         <source>No vertex shader found!</source>
         <translation>Kein VertexShader gefunden!</translation>
     </message>
@@ -360,14 +360,13 @@ Initialisiert als GL_RGBA8</translation>
         <translation>Konnte nicht erstellen: FragmentShader: </translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+369"/>
+        <location line="+7"/>
+        <location line="+14"/>
         <source>Fragment shader compiled with warnings: </source>
         <translation>FragmentShader kompiliert mit Warnungen: </translation>
     </message>
     <message>
-        <location line="+1050"/>
+        <location line="+1464"/>
         <source>Frame:%1/%2 Time:%3</source>
         <translation>Frame:%1/%2 Zeit:%3</translation>
     </message>
@@ -377,13 +376,13 @@ Initialisiert als GL_RGBA8</translation>
         <translation>&lt;table width = &quot;100%&quot;&gt;&lt;tr&gt;&lt;td&gt;Gesamt&lt;/td&gt;&lt;td align = &quot;center&quot;&gt;%1&lt;/td&gt;&lt;td&gt;Endgröße:%2&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Aktuelle &lt;/td&gt;&lt;td align = &quot;center&quot;&gt;Kachel:%3&lt;/td&gt;&lt;td&gt;At:%4&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Average/Kachel&lt;/td&gt;&lt;td align = &quot;center&quot;&gt;%5&lt;/td&gt; &lt;td&gt;ETA:%6&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;</translation>
     </message>
     <message>
-        <location line="-1444"/>
-        <location line="+367"/>
+        <location line="-1491"/>
+        <location line="+365"/>
         <source>Could not bind shaders: </source>
         <translation>Konnte Shaders nicht binden: </translation>
     </message>
     <message>
-        <location line="-345"/>
+        <location line="-343"/>
         <source>Trying to use a backbuffer, but no bufferType set.</source>
         <translation>Versuche Backbuffer zu gebrauchen, aber kein BufferTyp eingestellt.</translation>
     </message>
@@ -403,7 +402,7 @@ Initialisiert als GL_RGBA8</translation>
         <translation>Exrloader warnt, daß Bild: %1 nicht vollständig ist</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+139"/>
         <source>Not a valid texture: </source>
         <translation>Keine gültige Textur: </translation>
     </message>
@@ -424,11 +423,13 @@ Initialisiert als GL_RGBA8</translation>
     </message>
     <message>
         <location line="+6"/>
+        <location line="+13"/>
         <source>Buffer fragment shader compiled with warnings: </source>
         <translation>Buffer FragmentShader kompiliert mit Warnungen: </translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-373"/>
+        <location line="+366"/>
         <source>Could not link buffershader: </source>
         <translation>Buffershader konnte nicht verlinkt werden: </translation>
     </message>
@@ -438,7 +439,7 @@ Initialisiert als GL_RGBA8</translation>
         <translation>FBO Incomplete Fehler!!</translation>
     </message>
     <message>
-        <location line="+677"/>
+        <location line="+723"/>
         <source>Non valid FBO - previewBuffer</source>
         <translation>Ungültiger FBO - previewBuffer</translation>
     </message>
@@ -458,7 +459,7 @@ Initialisiert als GL_RGBA8</translation>
         <translation>PREVIEW BUFFER GESCHEITERT!</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+61"/>
         <source>Failed to bind FBO</source>
         <translation>Konnte FBO nicht binden</translation>
     </message>
@@ -473,12 +474,12 @@ Initialisiert als GL_RGBA8</translation>
         <translation>Konnte TargetBuffer nicht binden</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-48"/>
         <source>No front buffer sampler found in buffer shader. This doesn&apos;t make sense.</source>
         <translation>Kein Frontbuffersampler gefunden in BufferShader. Das ergibt keinen Sinn.</translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+93"/>
         <source>Failed to release target buffer</source>
         <translation>Konnte TargetBuffer nicht freigeben</translation>
     </message>
@@ -496,12 +497,11 @@ Initialisiert als GL_RGBA8</translation>
         <translation>Konnte hiresBuffer FBO nicht freigeben</translation>
     </message>
     <message>
-        <location line="-1482"/>
         <source>Could not link vertex + fragment shader: </source>
-        <translation>Vertex + Fragment-Shader konnte nicht verknüpft werden: </translation>
+        <translation type="vanished">Vertex + Fragment-Shader konnte nicht verknüpft werden: </translation>
     </message>
     <message>
-        <location line="+274"/>
+        <location line="-1251"/>
         <source>Unused sampler uniform: </source>
         <translation>Unbenutzte Probenehmeruniform: </translation>
     </message>
@@ -511,7 +511,7 @@ Initialisiert als GL_RGBA8</translation>
         <translation>Kein Buffershader Vertex Shader gefunden!</translation>
     </message>
     <message>
-        <location line="+1011"/>
+        <location line="+1054"/>
         <location line="+39"/>
         <source>Failed to bind previewBuffer FBO</source>
         <translation>Konnte previewBuffer FBO nicht binden</translation>
@@ -533,7 +533,7 @@ Initialisiert als GL_RGBA8</translation>
         <translation>[%1x%2] Aspekt=%3</translation>
     </message>
     <message>
-        <location line="+250"/>
+        <location line="+251"/>
         <source>Fix me</source>
         <translation>Reparier mich</translation>
     </message>
@@ -551,7 +551,7 @@ Initialisiert als GL_RGBA8</translation>
 <context>
     <name>Fragmentarium::GUI::MainWindow</name>
     <message>
-        <location filename="../Fragmentarium/GUI/MainWindow.cpp" line="+115"/>
+        <location filename="../Fragmentarium/GUI/MainWindow.cpp" line="+125"/>
         <source>Host Preprocessor Commands</source>
         <translation>Host Preprocessor Kommandos</translation>
     </message>
@@ -590,12 +590,12 @@ und speichern Sie es in einer Datei, bevor Sie es schließen.
     </message>
     <message>
         <location line="+35"/>
-        <location line="+2683"/>
+        <location line="+2700"/>
         <source>Unsaved changes</source>
         <translation>Ungespeicherte Änderungen</translation>
     </message>
     <message>
-        <location line="-2619"/>
+        <location line="-2636"/>
         <source>Add Preset</source>
         <translation>Voreinstellung hinzufügen</translation>
     </message>
@@ -626,24 +626,24 @@ und speichern Sie es in einer Datei, bevor Sie es schließen.
     </message>
     <message>
         <location line="+7"/>
-        <location line="+72"/>
+        <location line="+70"/>
         <source>Fragment Source (*.frag);;All Files (*.*)</source>
         <translation>Fragment-Quelle (*.frag);;Alle Dateien (*.*)</translation>
     </message>
     <message>
         <location line="-31"/>
-        <location line="+1508"/>
+        <location line="+1530"/>
         <source>Set combobox to &apos;custom-size&apos; to apply size.</source>
         <translation>Bitte die Combobox auf &apos;Angepasst&apos; einstellen um die Größe zu ändern.</translation>
     </message>
     <message>
-        <location line="-1499"/>
+        <location line="-1521"/>
         <location line="+16"/>
-        <location line="+928"/>
-        <location line="+1086"/>
+        <location line="+930"/>
+        <location line="+1106"/>
         <location line="+49"/>
         <location line="+70"/>
-        <location line="+371"/>
+        <location line="+368"/>
         <location line="+167"/>
         <location line="+10"/>
         <location line="+10"/>
@@ -654,22 +654,21 @@ und speichern Sie es in einer Datei, bevor Sie es schließen.
         <translation>Kein offener Tab</translation>
     </message>
     <message>
-        <location line="-2909"/>
-        <location line="+1396"/>
-        <location line="+1734"/>
+        <location line="-2928"/>
+        <location line="+1418"/>
+        <location line="+1732"/>
         <source>Save As</source>
         <translation>Speichern als</translation>
     </message>
     <message>
-        <location line="-3100"/>
+        <location line="-3120"/>
         <source>&lt;h1&gt;Fragmentarium&lt;/h1&gt;&lt;p&gt;Version %1. &lt;/p&gt;</source>
         <translation>&lt;h1&gt;Fragmentarium&lt;/h1&gt;&lt;p&gt;Version %1. &lt;/p&gt;</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;p&gt;An integrated environment for exploring GPU pixel graphics. &lt;/p&gt;&lt;p&gt;Created by Mikael Hvidtfeldt Christensen.&lt;br /&gt;Licensed and distributed under the LPGL or GPL license.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Notice&lt;/b&gt;: some fragment (GLSL) shaders are copyright by other authors, and may carry other licenses. Please check the fragment file header before redistributing.&lt;h1&gt;Acknowledgement&lt;/h1&gt;&lt;p&gt;Much of the inspiration and formulas for Fragmentarium came from the community at &lt;a href=http://www.fractalforums.com&gt;FractalForums.com&lt;/a&gt;, including Tom Beddard, Jan Kadlec, Iñigo Quilez, Buddhi, Jesse, and others. Special thanks goes out to Knighty and Kali for their great fragments. All fragments should include information about their origins - please notify me, if I made any mis-attributions.&lt;/p&gt;&lt;p&gt;The icons used are part of the &lt;a href=&quot;http://www.everaldo.com/crystal/&quot;&gt;Everaldo: Crystal&lt;/a&gt; project. &lt;/p&gt;&lt;p&gt;Fragmentarium is built using the &lt;a href=&quot;http://trolltech.com/developer/downloads/qt/index&quot;&gt;Qt cross-platform GUI framework&lt;/a&gt;. &lt;/p&gt;&lt;/p&gt;&lt;p&gt;&lt;table cellspacing=20&gt;&lt;th colspan=2 align=left&gt;Translations by Fractal Forums users&lt;/th&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;SCORPION&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;Crist-JRoger&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;German&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Dutch&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/p&gt;</source>
         <oldsource>&lt;p&gt;An integrated environment for exploring GPU pixel graphics. &lt;/p&gt;&lt;p&gt;Created by Mikael Hvidtfeldt Christensen.&lt;br /&gt;Licensed and distributed under the LPGL or GPL license.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Notice&lt;/b&gt;: some fragment (GLSL) shaders are copyright by other authors, and may carry other licenses. Please check the fragment file header before redistributing.&lt;h1&gt;Acknowledgement&lt;/h1&gt;&lt;p&gt;Much of the inspiration and formulas for Fragmentarium came from the community at &lt;a href=http://www.fractalforums.com&gt;FractalForums.com&lt;/a&gt;, including Tom Beddard, Jan Kadlec, IÃ±igo Quilez, Buddhi, Jesse, and others. Special thanks goes out to Knighty and Kali for their great fragments. All fragments should include information about their origins - please notify me, if I made any mis-attributions.&lt;/p&gt;&lt;p&gt;The icons used are part of the &lt;a href=&quot;http://www.everaldo.com/crystal/&quot;&gt;Everaldo: Crystal&lt;/a&gt; project. &lt;/p&gt;&lt;p&gt;Fragmentarium is built using the &lt;a href=&quot;http://trolltech.com/developer/downloads/qt/index&quot;&gt;Qt cross-platform GUI framework&lt;/a&gt;. &lt;/p&gt;&lt;/p&gt;&lt;p&gt;&lt;table cellspacing=20&gt;&lt;th colspan=2 align=left&gt;Translations by Fractal Forums users&lt;/th&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;SCORPION&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;Crist-JRoger&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;German&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Dutch&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/p&gt;</oldsource>
-        <translation>&lt;p&gt;Eine integrierten Umgebung um GPU pixel graphics zu erkunden. &lt;/p&gt;
+        <translation type="vanished">&lt;p&gt;Eine integrierten Umgebung um GPU pixel graphics zu erkunden. &lt;/p&gt;
 &lt;p&gt;Erstellt durch Mikael Hvidtfeldt Christensen.&lt;br /&gt;Untersteht und ist verteilt unter der der GNU Lesser General Public License [LPGL] oder GPL.&lt;/p&gt;
 &lt;p&gt;&lt;b&gt;Hinweis&lt;/b&gt;: Manche Fragment-GLSL-Shaders sind durch ihre jeweiligen Eigentümer urheberrechtlich geschützt. Bitte lesen sie den Fragment-Dateikopf vor einer Weiterverbreitung.
 &lt;h1&gt;Anerkennung&lt;/h1&gt;
@@ -686,7 +685,7 @@ und speichern Sie es in einer Datei, bevor Sie es schließen.
 &lt;/p&gt;</translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="+22"/>
         <source>About Fragmentarium</source>
         <translation>Über Fragmentarium</translation>
     </message>
@@ -768,7 +767,7 @@ und speichern Sie es in einer Datei, bevor Sie es schließen.
         <translation></translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+19"/>
         <source>Variable Editor (uniforms)</source>
         <translation>Variablen-Editor (uniforms)</translation>
     </message>
@@ -803,14 +802,14 @@ Diese Option ist wieder einzuschalten in Einstellungen</translation>
         <translation>Autorun einschalten</translation>
     </message>
     <message>
-        <location line="+676"/>
+        <location line="+690"/>
         <source>is too large!
 Must be less than 32769x32769</source>
         <translation>Zu groß!
 Muß kleiner sein als 32769x32769</translation>
     </message>
     <message>
-        <location line="+887"/>
+        <location line="+893"/>
         <source>Reloaded file: %1</source>
         <translation>Neu geladene Datei: %1</translation>
     </message>
@@ -852,7 +851,7 @@ Muß kleiner sein als 32769x32769</translation>
         <translation>Verfügbare Bildformate: </translation>
     </message>
     <message>
-        <location line="+231"/>
+        <location line="+228"/>
         <source>// Cannot read file %1:
 // %2
 </source>
@@ -876,7 +875,7 @@ Tab schließen ohne Änderungen zu speichern?</translation>
         <translation>Konnte OpenGL-Funktionen nicht auflösen die zur Aktivierung de ASMBrowsers benötigt sind</translation>
     </message>
     <message>
-        <location line="-2319"/>
+        <location line="-2336"/>
         <source>This is your first run of Fragmentarium.
 Please read this:
 
@@ -940,12 +939,12 @@ Bitte, lese unterstehendes:
     </message>
     <message>
         <location line="+8"/>
-        <location line="+2626"/>
+        <location line="+2644"/>
         <source>&amp;Save</source>
         <translation>&amp;Speichern</translation>
     </message>
     <message>
-        <location line="-2625"/>
+        <location line="-2643"/>
         <source>Ctrl+S</source>
         <translation></translation>
     </message>
@@ -1098,7 +1097,7 @@ Continue and loose changes?</source>
 Werden weiterhin Änderungen verlieren?</translation>
     </message>
     <message>
-        <location line="+306"/>
+        <location line="+304"/>
         <source>&lt;p&gt;Notice: the 3D view must have keyboard focus!&lt;/p&gt;&lt;h2&gt;2D&lt;/h2&gt;&lt;p&gt;&lt;ul&gt;&lt;li&gt;Left mousebutton: translate center.&lt;/li&gt;&lt;li&gt;Right mousebutton: zoom.&lt;/li&gt;&lt;li&gt;Wheel: zoom&lt;/li&gt;&lt;li&gt;A/D: left/right&lt;/li&gt;&lt;li&gt;W/S: up/down&lt;/li&gt;&lt;li&gt;Q/E: zoom in/out&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;h2&gt;3D&lt;/h2&gt;&lt;p&gt;&lt;ul&gt;&lt;li&gt;Shift+Right mouse button: shows menus when in fullscreen mode.&lt;/li&gt;&lt;li&gt;Left mouse button: change camera direction.&lt;/li&gt;&lt;li&gt;Right mouse button: move camera in screen plane.&lt;/li&gt;&lt;li&gt;Left+Right mouse button: zoom.&lt;/li&gt;&lt;li&gt;Shift+Left mouse button: rotate object (around origin).&lt;/li&gt;&lt;li&gt;Shift+Alt+Left mouse button: rotate object (around target).&lt;/li&gt;&lt;li&gt;Shift+Tilde (~) resets the view to look through origin (0,0,0)&lt;/li&gt;&lt;li&gt;Wheel: Move forward/backward&lt;/li&gt;&lt;li&gt;W/S: move forward/back.&lt;/li&gt;&lt;li&gt;A/D: move left/right.&lt;/li&gt;&lt;li&gt;Q/E: roll&lt;/li&gt;&lt;li&gt;1/3: increase/decrease step size x2&lt;/li&gt;&lt;li&gt;2: increase/decrease step size x10&lt;/li&gt;&lt;li&gt;Shift+Wheel: change step size&lt;/li&gt;&lt;li&gt;T/G: move up/down.&lt;/li&gt;&lt;li&gt;R/F: yaw&lt;/li&gt;&lt;li&gt;Y/H: pitch&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;h2&gt;Sliders&lt;/h2&gt;&lt;p&gt;When a (float) slider recieves a Right Mouse Button Click it opens an input dialog to set the step size.&lt;br&gt;&lt;b&gt;F7 Key&lt;/b&gt; opens the easing curve editor for the currently selected slider.&lt;/p&gt;</source>
         <translation>&lt;p&gt; Hinweis: Die 3D-Ansicht muss den Tastaturfokus haben! &lt;/p&gt; &lt;h2&gt; 2D &lt;/h2&gt; &lt;p&gt; &lt;ul&gt; &lt;li&gt; Linke Maustaste: Mitte übersetzen. &lt;/li&gt; &lt;li&gt; Rechte Maustaste: zoom. &lt;/li&gt; &lt;li&gt; Rad: zoom &lt;/li&gt; &lt;li&gt; A / D: links / rechts &lt;/li&gt; &lt;li&gt; B / S: hoch / runter &lt;/li&gt; &lt;li&gt; Q/E : Vergrößern/Verkleinern &lt;/li&gt; &lt;/ul&gt; &lt;/p&gt; &lt;h2&gt; 3D &lt;/h2&gt; &lt;p&gt; &lt;ul&gt; &lt;li&gt; Umschalt + Rechte Maustaste: Zeigt Menüs im Vollbildmodus an. &lt;/li &gt; &lt;li&gt; Linke Maustaste: Kamerarichtung ändern. &lt;/li&gt; &lt;li&gt; Rechte Maustaste: Kamera in Bildschirmebene bewegen. &lt;/li&gt; &lt;li&gt; Linke + rechte Maustaste: Zoomen. &lt;/li&gt; &lt;li &gt; Umschalt + linke Maustaste: Objekt drehen (um Ursprung). &lt;/Li&gt; &lt;li&gt; Umschalt + Alt + linke Maustaste: Objekt drehen (um Ziel). &lt;/Li&gt; &lt;li&gt; Umschalt + Tilde (~) wird zurückgesetzt Die Ansicht, um durch den Ursprung zu schauen (0,0,0) &lt;/li&gt; &lt;li&gt; Rad: Vorwärts/Rückwärts bewegen &lt;/li&gt; &lt;li&gt; W / S: Vorwärts / Rückwärts bewegen. &lt;/li&gt; &lt;li&gt; A/D: nach links/rechts bewegen. &lt;/Li&gt; &lt;li&gt; Q/E: rollen &lt;/li&gt; &lt;li&gt; 1/3: Schrittweite erhöhen/verringern x2 &lt;/li&gt; &lt;li&gt; 2: Schrittweite erhöhen / verringern Größe x10 &lt;/li&gt; &lt;li&gt; Umschalt + Rad: Schrittgröße ändern &lt;/li&gt; &lt;li&gt; T/G: Auf/Ab bewegen. &lt;/li&gt; &lt;li&gt; R/F: Gieren &lt;/li&gt; &lt;li &gt; Y/H: Tonhöhe &lt;/li&gt; &lt;/ul&gt; &lt;/p&gt; &lt;h2&gt; Schieberegler &lt;/h2&gt; &lt;p&gt; Wenn ein (Gleit-) Schieberegler eine rechte Maustaste erhält, wird ein Eingabedialog zum Festlegen der Schrittgröße geöffnet. &lt;br&gt; &lt;b&gt; F7-Taste &lt;/b&gt; öffnet die Beschleunigungskurve Editor für den aktuell ausgewählten Schieberegler. &lt;/p&gt;</translation>
     </message>
@@ -1108,7 +1107,7 @@ Werden weiterhin Änderungen verlieren?</translation>
         <translation>&lt;h2&gt; Stellt Befehle für Bild- und Animationsdialogfelder ein &lt;/h2&gt; &lt;p&gt; &lt;ul&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setAnimationLength (int); &lt;/b&gt; &lt;/li&gt; Legt die Gesamtdauer der Animation in Sekunden fest. &lt;/p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setTileWidth (int); &lt;/b&gt; &lt;/li&gt; &lt;li&gt; &lt;b&gt; void setTileHeight (int); &lt;/b&gt; &lt;/li&gt; Legt die Kachel fest width and height. &lt;/p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setTileMax (int); &lt;/b&gt; &lt;/li&gt; Legt die Anzahl der Zeilen- und Spaltenkacheln fest. Dieser Wert ist ein Quadrat = Gesamtkacheln. &lt;/p &gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setSubFrames (int); &lt;/b&gt; &lt;/li&gt; Legt die Anzahl der zu akkumulierenden Frames fest. &lt;/p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setOutputBaseFileName (String) ; &lt;/b&gt; &lt;/li&gt; Legt den Dateinamen für das gespeicherte Bild fest. Wenn das Skript die vollständige Kontrolle hat, muss dies für jeden Frame vom Skript festgelegt werden. Wenn die Animation Frag-Dateieinstellungen, Keyframes usw. verwendet. dann muss dies nur einmal auf basename gesetzt werden und Fragmentarium fügt einen mit 5 Ziffern aufgefüllten Index hinzu. &lt;/p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setFps (int); &lt;/b&gt; &lt;/li&gt; Setzt den Bilder pro Sekunde für das Rendern. &lt;/p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setStartFrame (int); &lt;/b&gt; &lt;/li&gt; Legt die Startbildnummer für das Rendern einer Reihe von Bildern fest. &lt;/p&gt; &lt; p&gt; &lt;li&gt; &lt;b&gt; void setEndFrame (int); &lt;/b&gt; &lt;/li&gt; Legt die End-Frame-Nummer für das Rendern eines Framebereichs fest. &lt;/p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setAnimation ( bool); &lt;/b&gt; &lt;/li&gt; FALSE setzt die Animation ausschließlich auf Skriptsteuerung. &lt;br&gt; TRUE aktiviert die Steuerung über Keyframes und Beschleunigungskurven. &lt;/p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setPreview (bool); &lt;/b&gt; &lt;/li&gt; TRUE zeigt eine Vorschau der Bilder in einem Fenster auf dem Desktop an, anstatt die Bilddateien zu speichern. &lt;br&gt; WARNUNG !!! Dies öffnet ein Fenster für jeden Frame und schließt es, wenn der nächste zur Anzeige bereit ist. &lt;/p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setAutoSave (bool); &lt;/b&gt; &lt;/li&gt; TRUE wird gespeichert Dateien im Unterordner. &lt;br&gt; FALSE verwendet den von setOutputBaseFileName (String) festgelegten Pfad. &lt;/p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setUniqueID (bool); &lt;/b&gt; &lt;/li&gt; Das Gleiche wie &quot;Eindeutige ID zum Dateinamen hinzufügen&quot; im HiResolution- und Animationsdialog. &lt;br&gt; &lt;/p&gt; &lt;/ul&gt; &lt;/p&gt;</translation>
     </message>
     <message>
-        <location line="+234"/>
+        <location line="+236"/>
         <source>EXR &amp;Tools</source>
         <translation>EXR &amp;Werkzeuge</translation>
     </message>
@@ -1394,12 +1393,31 @@ Werden weiterhin Änderungen verlieren?</translation>
     </message>
     <message>
         <location line="-986"/>
-        <location line="+2683"/>
+        <location line="+2700"/>
         <source>Continue</source>
         <translation>Fortsetzen</translation>
     </message>
     <message>
-        <location line="-1738"/>
+        <location line="-2499"/>
+        <source>&lt;p&gt;An integrated environment for exploring GPU pixel graphics. &lt;/p&gt;&lt;p&gt;Created by Mikael Hvidtfeldt Christensen.&lt;br /&gt;Licensed and distributed under the LPGL or GPL license.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Notice&lt;/b&gt;: some fragment (GLSL) shaders are copyright by other authors, and may carry other licenses. Please check the fragment file header before redistributing.&lt;h1&gt;Acknowledgement&lt;/h1&gt;&lt;p&gt;Much of the inspiration and formulas for Fragmentarium came from the community at &lt;a href=http://www.fractalforums.com&gt;FractalForums.com&lt;/a&gt;, including Tom Beddard, Jan Kadlec, Iñigo Quilez, Buddhi, Jesse, and others. Special thanks goes out to Knighty and Kali for their great fragments and claude for all his help with improvements. All fragments should include information about their origins - please notify me, if I made any mis-attributions.&lt;/p&gt;&lt;p&gt;The icons used are part of the &lt;a href=&quot;http://www.everaldo.com/crystal/&quot;&gt;Everaldo: Crystal&lt;/a&gt; project. &lt;/p&gt;&lt;p&gt;Fragmentarium is built using the &lt;a href=&quot;http://trolltech.com/developer/downloads/qt/index&quot;&gt;Qt cross-platform GUI framework&lt;/a&gt;. &lt;/p&gt;&lt;/p&gt;&lt;p&gt;&lt;table cellspacing=20&gt;&lt;th colspan=2 align=left&gt;Translations by Fractal Forums users&lt;/th&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;SCORPION&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;Crist-JRoger&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;German&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Dutch&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Eine integrierten Umgebung um GPU pixel graphics zu erkunden. &lt;/p&gt;
+&lt;p&gt;Erstellt durch Mikael Hvidtfeldt Christensen.&lt;br /&gt;Untersteht und ist verteilt unter der der GNU Lesser General Public License [LPGL] oder GPL.&lt;/p&gt;
+&lt;p&gt;&lt;b&gt;Hinweis&lt;/b&gt;: Manche Fragment-GLSL-Shaders sind durch ihre jeweiligen Eigentümer urheberrechtlich geschützt. Bitte lesen sie den Fragment-Dateikopf vor einer Weiterverbreitung.
+&lt;h1&gt;Anerkennung&lt;/h1&gt;
+&lt;p&gt;Viele der Inspirationen und Formeln kamen von &lt;a href=&quot;http://www.fractalforums.com&quot;&gt;Fractal Forums&lt;/a&gt;, unter anderen von Tom Beddard, Jan Kadlec, Iñigo Quilez, Buddhi und Jesse. Ein besonderer Dank gilt Knighty und Kali for ihre großartigen Fragmente und claude für all seine Hilfe bei Verbesserungen. Alle Fragmente sollten Information über ihren Ursprung enthalten - Bitte melden Sie mir, wenn ich mich in dieser Hinsicht irgenwo geirrt habe.&lt;/p&gt;
+&lt;p&gt;Die gebrauchten Icons sind Teil des &lt;a href=&quot;http://www.everaldo.com/crystal/&quot;&gt;Everaldo: Crystal&lt;/a&gt;-Projekts. &lt;/p&gt;
+&lt;p&gt;Fragmentarium is erstellt unter Nutzung des &lt;a href=&quot;http://trolltech.com/developer/downloads/qt/index&quot;&gt;Qt plattformübergreifenden GUI Frameworks&lt;/a&gt;. &lt;/p&gt;
+
+&lt;p&gt;
+&lt;table cellspacing=20&gt;&lt;th colspan=2 align=left&gt;Übersetzungen durch FractalForums.com-Benutzer&lt;/th&gt;
+&lt;tr&gt;&lt;td&gt;Russisch&lt;/td&gt;&lt;td align=center&gt;SCORPION&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;Russisch&lt;/td&gt;&lt;td align=center&gt;Crist-JRoger&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;Deutsche&lt;/td&gt;&lt;td align=center&gt;sabine62&lt;/td&gt;&lt;/tr&gt;
+&lt;/table&gt;
+&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location line="+744"/>
         <source>Windows</source>
         <translation></translation>
     </message>
@@ -1424,28 +1442,34 @@ Werden weiterhin Änderungen verlieren?</translation>
         <translation>// Erstellt: </translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+8"/>
+        <location line="+15"/>
+        <source>Do you want to use it? &lt;br&gt;&lt;br&gt;This will overwrite any existing files!</source>
+        <translation>Willst du es benutzen? &lt;br&gt; &lt;br&gt; Dies überschreibt alle vorhandenen Dateien!</translation>
+    </message>
+    <message>
         <location line="+16"/>
-        <location line="+420"/>
+        <location line="+10"/>
+        <location line="+17"/>
+        <location line="+5"/>
+        <location line="+427"/>
         <location line="+19"/>
         <location line="+514"/>
         <location line="+72"/>
-        <location line="+1121"/>
+        <location line="+1119"/>
         <location line="+22"/>
         <source>Fragmentarium</source>
         <translation></translation>
     </message>
     <message>
-        <location line="-2192"/>
+        <location line="-2205"/>
         <source>Could not create directory %1:
 .</source>
         <translation>Konnte Verzeichnis nicht erstellen: %1:
 .</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+436"/>
+        <location line="+10"/>
+        <location line="+449"/>
         <location line="+606"/>
         <source>Cannot write file %1:
 %2.</source>
@@ -1453,12 +1477,12 @@ Werden weiterhin Änderungen verlieren?</translation>
 %2.</translation>
     </message>
     <message>
-        <location line="-1036"/>
+        <location line="-1049"/>
         <source>Saved fragment + settings as: </source>
         <translation>Fragment und Einstellungen gespeichert als: </translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+16"/>
         <source>Could not copy dependency:
 &apos;%1&apos; to 
 &apos;%2&apos;.</source>
@@ -1470,7 +1494,7 @@ Werden weiterhin Änderungen verlieren?</translation>
 &apos;%2&apos;.</translation>
     </message>
     <message>
-        <location line="+33"/>
+        <location line="+34"/>
         <source>Do you want to try again?</source>
         <translation>Nochmal versuchen?</translation>
     </message>
@@ -1485,7 +1509,7 @@ Werden weiterhin Änderungen verlieren?</translation>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location line="+276"/>
+        <location line="+282"/>
         <location line="+41"/>
         <source>Saved file : </source>
         <translation>Datei gespeichert : </translation>
@@ -1529,14 +1553,15 @@ Werden weiterhin Änderungen verlieren?</translation>
     <message>
         <location line="+13"/>
         <location line="+473"/>
-        <location line="+1257"/>
+        <location line="+1255"/>
+        <location line="+199"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Kann Datei nicht lesen %1:
 %2.</translation>
     </message>
     <message>
-        <location line="-1723"/>
+        <location line="-1920"/>
         <source>Settings loaded from file</source>
         <translation>Einstellungen geladen aus Datei</translation>
     </message>
@@ -1731,7 +1756,7 @@ Möchten Sie es neu laden?</translation>
         <translation>Fragment nicht lauffähig.</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+55"/>
         <source>Compiled script in %1 ms.</source>
         <translation>Script Kompiliert in %1 ms.</translation>
     </message>
@@ -1757,11 +1782,12 @@ Möchten Sie es neu laden?</translation>
     </message>
     <message>
         <location line="+42"/>
+        <location line="+971"/>
         <source>Loaded file: %1</source>
         <translation>Geladene Datei: %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="-963"/>
         <source>Unnamed</source>
         <translation>Unbenannt</translation>
     </message>
@@ -1776,30 +1802,55 @@ Möchten Sie es neu laden?</translation>
         <translation>Wenn das Preset gesperrte Variablen ändert, ist erneutes Wählen von &quot;Build&quot; erforderlich.</translation>
     </message>
     <message>
-        <source>There are unsaved changes.%1
-Continue will discard changes.</source>
-        <translation type="vanished">Es gibt Registerkarten mit nicht gespeicherten Änderungen.
-%1
-Werden weiterhin Änderungen verlieren?</translation>
-    </message>
-    <message>
         <source>
 To keep Easing curves you must
 add a preset named &quot;Range&quot;
 and save before closing!</source>
-        <translation type="vanished">
+        <translation type="obsolete">
 Um Beschleunigungskurven zu halten, müssen Sie
 Füge ein Preset mit dem Namen &quot;Range&quot; hinzu
 und vor dem Schließen speichern!</translation>
     </message>
     <message>
-        <location line="-2647"/>
-        <location line="+2683"/>
+        <source>Cannot read file %1:
+%2
+</source>
+        <translation type="obsolete">Kann Datei nicht lesen %1:
+%2. {1:?} {2
+?}</translation>
+    </message>
+    <message>
+        <source>There are unsaved changes.%1
+Continue will discard changes.</source>
+        <translation type="obsolete">Es gibt Registerkarten mit nicht gespeicherten Änderungen.
+%1
+Werden weiterhin Änderungen verlieren?</translation>
+    </message>
+    <message>
+        <location line="+920"/>
+        <source>CMD Script (*.fqs);;All Files (*.*)</source>
+        <translation>CmdScript (*.fqs);;Alle Dateien (*.*)</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Bind CMD script to F6 key</source>
+        <translation>Binden Sie das Befehlsskript an die Taste F6</translation>
+    </message>
+    <message>
+        <location line="-3586"/>
+        <location line="+2700"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="-1531"/>
+        <source>Could not remove dependency:
+&apos;%1&apos;</source>
+        <translation>Abhängigkeit konnte nicht entfernt werden:
+&apos;%1&apos;</translation>
+    </message>
+    <message>
+        <location line="+1575"/>
         <location line="+10"/>
         <location line="+10"/>
         <source>Launching web browser...</source>
@@ -1874,7 +1925,7 @@ und vor dem Schließen speichern!</translation>
         <translation>Muß eine .frag- oder .fragparams-Datei sein.</translation>
     </message>
     <message>
-        <location line="+338"/>
+        <location line="+339"/>
         <source>#endpreset not found!</source>
         <translation>#endpreset nicht gefunden!</translation>
     </message>
@@ -1923,6 +1974,7 @@ und vor dem Schließen speichern!</translation>
     </message>
     <message>
         <location line="+65"/>
+        <location line="+113"/>
         <source>Error %1 at line %2</source>
         <translation>Fehler %1 in Zeile %2</translation>
     </message>
@@ -1996,7 +2048,7 @@ und vor dem Schließen speichern!</translation>
 <context>
     <name>Fragmentarium::GUI::SamplerWidget</name>
     <message>
-        <location filename="../Fragmentarium/GUI/VariableWidget.cpp" line="+765"/>
+        <location filename="../Fragmentarium/GUI/VariableWidget.cpp" line="+781"/>
         <source>Select a Texture</source>
         <translation>Wähle Textur</translation>
     </message>
@@ -2089,22 +2141,22 @@ Oder erstellen Sie sie mit der Tastenkombination &quot;F7&quot; für den ausgew�
         <translation> Einstellungen aufs Clipboard</translation>
     </message>
     <message>
-        <location line="+118"/>
+        <location line="+119"/>
         <source>%1 locked variables: %2</source>
         <translation>%1 gesperrte Variablen: %2</translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+141"/>
         <source>Unsupported parameter</source>
         <translation>Ununterstützter Parameter</translation>
     </message>
     <message>
-        <location line="+144"/>
+        <location line="+166"/>
         <source>Expected a key value pair, found: </source>
         <translation>Erwartete key value pair, fand: </translation>
     </message>
     <message>
-        <location line="+21"/>
+        <location line="+23"/>
         <source>Could not find: </source>
         <translation>Konnte nicht finden: </translation>
     </message>
@@ -2637,7 +2689,7 @@ Oder erstellen Sie sie mit der Tastenkombination &quot;F7&quot; für den ausgew�
 <context>
     <name>Preprocessor</name>
     <message>
-        <location filename="../Fragmentarium/Parser/Preprocessor.cpp" line="+156"/>
+        <location filename="../Fragmentarium/Parser/Preprocessor.cpp" line="+253"/>
         <source>Including file: </source>
         <translation>Schließt Datei ein: </translation>
     </message>
@@ -2647,7 +2699,7 @@ Oder erstellen Sie sie mit der Tastenkombination &quot;F7&quot; für den ausgew�
         <translation>Schließt BufferShader  ein: </translation>
     </message>
     <message>
-        <location line="+374"/>
+        <location line="+380"/>
         <source>Parse: </source>
         <translation></translation>
     </message>
@@ -2655,7 +2707,7 @@ Oder erstellen Sie sie mit der Tastenkombination &quot;F7&quot; für den ausgew�
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../Fragmentarium/GUI/MainWindow.cpp" line="-978"/>
+        <location filename="../Fragmentarium/GUI/MainWindow.cpp" line="-1092"/>
         <source>Could not locate directory in: </source>
         <translation>Konnte Verzeichnis nicht finden in: </translation>
     </message>
@@ -2668,7 +2720,12 @@ Oder erstellen Sie sie mit der Tastenkombination &quot;F7&quot; für den ausgew�
 <context>
     <name>SyntopiaCore::Logging::ListWidget</name>
     <message>
-        <location filename="../SyntopiaCore/Logging/ListWidgetLogger.h" line="+28"/>
+        <location filename="../SyntopiaCore/Logging/ListWidgetLogger.h" line="+31"/>
+        <source>Open file</source>
+        <translation>Datei öffnen</translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Copy to Clipboard</source>
         <translation>Kopieren aufs Clipboard</translation>
     </message>
@@ -2678,7 +2735,7 @@ Oder erstellen Sie sie mit der Tastenkombination &quot;F7&quot; für den ausgew�
         <translation>Löschen</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+32"/>
         <source>Copied %1 lines to clipboard</source>
         <translation>%1 Zeilen aufs Clipboard kopiert</translation>
     </message>

--- a/Fragmentarium-Source/Translations/Fragmentarium_en.ts
+++ b/Fragmentarium-Source/Translations/Fragmentarium_en.ts
@@ -33,7 +33,7 @@
 <context>
     <name>Camera2D</name>
     <message>
-        <location filename="../Fragmentarium/GUI/CameraControl.cpp" line="+474"/>
+        <location filename="../Fragmentarium/GUI/CameraControl.cpp" line="+478"/>
         <source>Camera: Click on 2D window for key focus. See Help Menu for more.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -48,7 +48,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
+        <location line="+58"/>
         <location line="+6"/>
         <location line="+6"/>
         <location line="+6"/>
@@ -59,7 +59,7 @@
 <context>
     <name>Camera3D</name>
     <message>
-        <location line="-457"/>
+        <location line="-486"/>
         <source>Could not find Eye interface widget</source>
         <translation type="unfinished"></translation>
     </message>
@@ -257,7 +257,7 @@
 <context>
     <name>Fragmentarium::GUI::ComboSlider</name>
     <message>
-        <location filename="../Fragmentarium/GUI/VariableWidget.h" line="+93"/>
+        <location filename="../Fragmentarium/GUI/VariableWidget.h" line="+104"/>
         <source>Slider Step Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
@@ -275,7 +275,7 @@
 <context>
     <name>Fragmentarium::GUI::DisplayWidget</name>
     <message>
-        <location filename="../Fragmentarium/GUI/DisplayWidget.cpp" line="+120"/>
+        <location filename="../Fragmentarium/GUI/DisplayWidget.cpp" line="+125"/>
         <source>Setting display update timer to %1 ms (max %2 FPS).</source>
         <translation type="unfinished"></translation>
     </message>
@@ -307,7 +307,7 @@ Initialized as GL_RGBA8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+133"/>
+        <location line="+138"/>
         <source>Asked gpu for %1 mip-map levels.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -337,7 +337,7 @@ Initialized as GL_RGBA8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+158"/>
+        <location line="+176"/>
         <source>No vertex shader found!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -357,14 +357,13 @@ Initialized as GL_RGBA8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+369"/>
+        <location line="+7"/>
+        <location line="+14"/>
         <source>Fragment shader compiled with warnings: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1050"/>
+        <location line="+1464"/>
         <source>Frame:%1/%2 Time:%3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -374,13 +373,13 @@ Initialized as GL_RGBA8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1444"/>
-        <location line="+367"/>
+        <location line="-1491"/>
+        <location line="+365"/>
         <source>Could not bind shaders: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-345"/>
+        <location line="-343"/>
         <source>Trying to use a backbuffer, but no bufferType set.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -400,7 +399,7 @@ Initialized as GL_RGBA8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+139"/>
         <source>Not a valid texture: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -421,11 +420,13 @@ Initialized as GL_RGBA8</source>
     </message>
     <message>
         <location line="+6"/>
+        <location line="+13"/>
         <source>Buffer fragment shader compiled with warnings: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-373"/>
+        <location line="+366"/>
         <source>Could not link buffershader: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -435,7 +436,7 @@ Initialized as GL_RGBA8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+677"/>
+        <location line="+723"/>
         <source>Non valid FBO - previewBuffer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -455,7 +456,7 @@ Initialized as GL_RGBA8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+61"/>
         <source>Failed to bind FBO</source>
         <translation type="unfinished"></translation>
     </message>
@@ -470,12 +471,12 @@ Initialized as GL_RGBA8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-48"/>
         <source>No front buffer sampler found in buffer shader. This doesn&apos;t make sense.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+93"/>
         <source>Failed to release target buffer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -493,12 +494,7 @@ Initialized as GL_RGBA8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1482"/>
-        <source>Could not link vertex + fragment shader: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+274"/>
+        <location line="-1251"/>
         <source>Unused sampler uniform: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -508,7 +504,7 @@ Initialized as GL_RGBA8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1011"/>
+        <location line="+1054"/>
         <location line="+39"/>
         <source>Failed to bind previewBuffer FBO</source>
         <translation type="unfinished"></translation>
@@ -530,7 +526,7 @@ Initialized as GL_RGBA8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+250"/>
+        <location line="+251"/>
         <source>Fix me</source>
         <translation type="unfinished"></translation>
     </message>
@@ -548,7 +544,7 @@ Initialized as GL_RGBA8</source>
 <context>
     <name>Fragmentarium::GUI::MainWindow</name>
     <message>
-        <location filename="../Fragmentarium/GUI/MainWindow.cpp" line="+115"/>
+        <location filename="../Fragmentarium/GUI/MainWindow.cpp" line="+125"/>
         <source>Host Preprocessor Commands</source>
         <translation type="unfinished"></translation>
     </message>
@@ -569,12 +565,12 @@ Initialized as GL_RGBA8</source>
     </message>
     <message>
         <location line="+35"/>
-        <location line="+2683"/>
+        <location line="+2700"/>
         <source>Unsaved changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2619"/>
+        <location line="-2636"/>
         <source>Add Preset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -605,24 +601,24 @@ Initialized as GL_RGBA8</source>
     </message>
     <message>
         <location line="+7"/>
-        <location line="+72"/>
+        <location line="+70"/>
         <source>Fragment Source (*.frag);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-31"/>
-        <location line="+1508"/>
+        <location line="+1530"/>
         <source>Set combobox to &apos;custom-size&apos; to apply size.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1499"/>
+        <location line="-1521"/>
         <location line="+16"/>
-        <location line="+928"/>
-        <location line="+1086"/>
+        <location line="+930"/>
+        <location line="+1106"/>
         <location line="+49"/>
         <location line="+70"/>
-        <location line="+371"/>
+        <location line="+368"/>
         <location line="+167"/>
         <location line="+10"/>
         <location line="+10"/>
@@ -633,24 +629,19 @@ Initialized as GL_RGBA8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2909"/>
-        <location line="+1396"/>
-        <location line="+1734"/>
+        <location line="-2928"/>
+        <location line="+1418"/>
+        <location line="+1732"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3100"/>
+        <location line="-3120"/>
         <source>&lt;h1&gt;Fragmentarium&lt;/h1&gt;&lt;p&gt;Version %1. &lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>&lt;p&gt;An integrated environment for exploring GPU pixel graphics. &lt;/p&gt;&lt;p&gt;Created by Mikael Hvidtfeldt Christensen.&lt;br /&gt;Licensed and distributed under the LPGL or GPL license.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Notice&lt;/b&gt;: some fragment (GLSL) shaders are copyright by other authors, and may carry other licenses. Please check the fragment file header before redistributing.&lt;h1&gt;Acknowledgement&lt;/h1&gt;&lt;p&gt;Much of the inspiration and formulas for Fragmentarium came from the community at &lt;a href=http://www.fractalforums.com&gt;FractalForums.com&lt;/a&gt;, including Tom Beddard, Jan Kadlec, Iñigo Quilez, Buddhi, Jesse, and others. Special thanks goes out to Knighty and Kali for their great fragments. All fragments should include information about their origins - please notify me, if I made any mis-attributions.&lt;/p&gt;&lt;p&gt;The icons used are part of the &lt;a href=&quot;http://www.everaldo.com/crystal/&quot;&gt;Everaldo: Crystal&lt;/a&gt; project. &lt;/p&gt;&lt;p&gt;Fragmentarium is built using the &lt;a href=&quot;http://trolltech.com/developer/downloads/qt/index&quot;&gt;Qt cross-platform GUI framework&lt;/a&gt;. &lt;/p&gt;&lt;/p&gt;&lt;p&gt;&lt;table cellspacing=20&gt;&lt;th colspan=2 align=left&gt;Translations by Fractal Forums users&lt;/th&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;SCORPION&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;Crist-JRoger&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;German&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Dutch&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+19"/>
+        <location line="+22"/>
         <source>About Fragmentarium</source>
         <translation type="unfinished"></translation>
     </message>
@@ -685,7 +676,7 @@ Initialized as GL_RGBA8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+19"/>
         <source>Variable Editor (uniforms)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -718,13 +709,19 @@ This option may be re-enabled through Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+676"/>
+        <location line="+652"/>
+        <source>Could not remove dependency:
+&apos;%1&apos;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+38"/>
         <source>is too large!
 Must be less than 32769x32769</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+887"/>
+        <location line="+893"/>
         <source>Reloaded file: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -765,7 +762,7 @@ Must be less than 32769x32769</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
+        <location line="+228"/>
         <source>// Cannot read file %1:
 // %2
 </source>
@@ -777,7 +774,7 @@ Must be less than 32769x32769</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2319"/>
+        <location line="-2336"/>
         <source>This is your first run of Fragmentarium.
 Please read this:
 
@@ -832,12 +829,12 @@ Please read this:
     </message>
     <message>
         <location line="+8"/>
-        <location line="+2626"/>
+        <location line="+2644"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2625"/>
+        <location line="-2643"/>
         <source>Ctrl+S</source>
         <translation type="unfinished"></translation>
     </message>
@@ -982,22 +979,7 @@ Please read this:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+73"/>
-        <source>There are unsaved changes.
-%1
-Continue will discard changes.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>
-Tip: Update easing curves in preset
-and save to file before closing.
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+232"/>
+        <location line="+304"/>
         <source>&lt;p&gt;Notice: the 3D view must have keyboard focus!&lt;/p&gt;&lt;h2&gt;2D&lt;/h2&gt;&lt;p&gt;&lt;ul&gt;&lt;li&gt;Left mousebutton: translate center.&lt;/li&gt;&lt;li&gt;Right mousebutton: zoom.&lt;/li&gt;&lt;li&gt;Wheel: zoom&lt;/li&gt;&lt;li&gt;A/D: left/right&lt;/li&gt;&lt;li&gt;W/S: up/down&lt;/li&gt;&lt;li&gt;Q/E: zoom in/out&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;h2&gt;3D&lt;/h2&gt;&lt;p&gt;&lt;ul&gt;&lt;li&gt;Shift+Right mouse button: shows menus when in fullscreen mode.&lt;/li&gt;&lt;li&gt;Left mouse button: change camera direction.&lt;/li&gt;&lt;li&gt;Right mouse button: move camera in screen plane.&lt;/li&gt;&lt;li&gt;Left+Right mouse button: zoom.&lt;/li&gt;&lt;li&gt;Shift+Left mouse button: rotate object (around origin).&lt;/li&gt;&lt;li&gt;Shift+Alt+Left mouse button: rotate object (around target).&lt;/li&gt;&lt;li&gt;Shift+Tilde (~) resets the view to look through origin (0,0,0)&lt;/li&gt;&lt;li&gt;Wheel: Move forward/backward&lt;/li&gt;&lt;li&gt;W/S: move forward/back.&lt;/li&gt;&lt;li&gt;A/D: move left/right.&lt;/li&gt;&lt;li&gt;Q/E: roll&lt;/li&gt;&lt;li&gt;1/3: increase/decrease step size x2&lt;/li&gt;&lt;li&gt;2: increase/decrease step size x10&lt;/li&gt;&lt;li&gt;Shift+Wheel: change step size&lt;/li&gt;&lt;li&gt;T/G: move up/down.&lt;/li&gt;&lt;li&gt;R/F: yaw&lt;/li&gt;&lt;li&gt;Y/H: pitch&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;h2&gt;Sliders&lt;/h2&gt;&lt;p&gt;When a (float) slider recieves a Right Mouse Button Click it opens an input dialog to set the step size.&lt;br&gt;&lt;b&gt;F7 Key&lt;/b&gt; opens the easing curve editor for the currently selected slider.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1007,7 +989,7 @@ and save to file before closing.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+234"/>
+        <location line="+236"/>
         <source>EXR &amp;Tools</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1292,13 +1274,34 @@ and save to file before closing.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-986"/>
-        <location line="+2683"/>
+        <location line="-989"/>
+        <location line="+2699"/>
+        <source>There are unsaved changes.
+%1
+Continue will discard changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-2698"/>
+        <source>
+Tip: Update easing curves in preset
+and save to file before closing.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <location line="+2700"/>
         <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1738"/>
+        <location line="-2499"/>
+        <source>&lt;p&gt;An integrated environment for exploring GPU pixel graphics. &lt;/p&gt;&lt;p&gt;Created by Mikael Hvidtfeldt Christensen.&lt;br /&gt;Licensed and distributed under the LPGL or GPL license.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Notice&lt;/b&gt;: some fragment (GLSL) shaders are copyright by other authors, and may carry other licenses. Please check the fragment file header before redistributing.&lt;h1&gt;Acknowledgement&lt;/h1&gt;&lt;p&gt;Much of the inspiration and formulas for Fragmentarium came from the community at &lt;a href=http://www.fractalforums.com&gt;FractalForums.com&lt;/a&gt;, including Tom Beddard, Jan Kadlec, Iñigo Quilez, Buddhi, Jesse, and others. Special thanks goes out to Knighty and Kali for their great fragments and claude for all his help with improvements. All fragments should include information about their origins - please notify me, if I made any mis-attributions.&lt;/p&gt;&lt;p&gt;The icons used are part of the &lt;a href=&quot;http://www.everaldo.com/crystal/&quot;&gt;Everaldo: Crystal&lt;/a&gt; project. &lt;/p&gt;&lt;p&gt;Fragmentarium is built using the &lt;a href=&quot;http://trolltech.com/developer/downloads/qt/index&quot;&gt;Qt cross-platform GUI framework&lt;/a&gt;. &lt;/p&gt;&lt;/p&gt;&lt;p&gt;&lt;table cellspacing=20&gt;&lt;th colspan=2 align=left&gt;Translations by Fractal Forums users&lt;/th&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;SCORPION&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;Crist-JRoger&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;German&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Dutch&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+744"/>
         <source>Windows</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1323,46 +1326,52 @@ and save to file before closing.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+8"/>
+        <location line="+15"/>
+        <source>Do you want to use it? &lt;br&gt;&lt;br&gt;This will overwrite any existing files!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location line="+16"/>
-        <location line="+420"/>
+        <location line="+10"/>
+        <location line="+17"/>
+        <location line="+5"/>
+        <location line="+427"/>
         <location line="+19"/>
         <location line="+514"/>
         <location line="+72"/>
-        <location line="+1121"/>
+        <location line="+1119"/>
         <location line="+22"/>
         <source>Fragmentarium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2192"/>
+        <location line="-2205"/>
         <source>Could not create directory %1:
 .</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+436"/>
+        <location line="+10"/>
+        <location line="+449"/>
         <location line="+606"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1036"/>
+        <location line="-1049"/>
         <source>Saved fragment + settings as: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+16"/>
         <source>Could not copy dependency:
 &apos;%1&apos; to 
 &apos;%2&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
+        <location line="+34"/>
         <source>Do you want to try again?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1377,7 +1386,7 @@ and save to file before closing.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+276"/>
+        <location line="+282"/>
         <location line="+41"/>
         <source>Saved file : </source>
         <translation type="unfinished"></translation>
@@ -1421,13 +1430,14 @@ and save to file before closing.
     <message>
         <location line="+13"/>
         <location line="+473"/>
-        <location line="+1257"/>
+        <location line="+1255"/>
+        <location line="+199"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1723"/>
+        <location line="-1920"/>
         <source>Settings loaded from file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1620,7 +1630,7 @@ Would you like to reload it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+55"/>
         <source>Compiled script in %1 ms.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1646,11 +1656,12 @@ Would you like to reload it?</source>
     </message>
     <message>
         <location line="+42"/>
+        <location line="+971"/>
         <source>Loaded file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="-963"/>
         <source>Unnamed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1665,19 +1676,23 @@ Would you like to reload it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2647"/>
-        <location line="+2683"/>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-4"/>
-        <source>There are unsaved changes.%1
-Continue will discard changes.</source>
+        <location line="+920"/>
+        <source>CMD Script (*.fqs);;All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
+        <source>Bind CMD script to F6 key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-3586"/>
+        <location line="+2700"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-2"/>
         <source>
 To keep Easing curves you must
 add a preset named &quot;Range&quot;
@@ -1760,7 +1775,7 @@ and save before closing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+338"/>
+        <location line="+339"/>
         <source>#endpreset not found!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1808,6 +1823,7 @@ and save before closing!</source>
     </message>
     <message>
         <location line="+65"/>
+        <location line="+113"/>
         <source>Error %1 at line %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1881,7 +1897,7 @@ and save before closing!</source>
 <context>
     <name>Fragmentarium::GUI::SamplerWidget</name>
     <message>
-        <location filename="../Fragmentarium/GUI/VariableWidget.cpp" line="+765"/>
+        <location filename="../Fragmentarium/GUI/VariableWidget.cpp" line="+781"/>
         <source>Select a Texture</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1973,22 +1989,22 @@ Or create them with &quot;F7&quot; hotkey for the selected float slider.</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+118"/>
+        <location line="+119"/>
         <source>%1 locked variables: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+141"/>
         <source>Unsupported parameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
+        <location line="+166"/>
         <source>Expected a key value pair, found: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
+        <location line="+23"/>
         <source>Could not find: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -2520,7 +2536,7 @@ Or create them with &quot;F7&quot; hotkey for the selected float slider.</source
 <context>
     <name>Preprocessor</name>
     <message>
-        <location filename="../Fragmentarium/Parser/Preprocessor.cpp" line="+156"/>
+        <location filename="../Fragmentarium/Parser/Preprocessor.cpp" line="+253"/>
         <source>Including file: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -2530,7 +2546,7 @@ Or create them with &quot;F7&quot; hotkey for the selected float slider.</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+374"/>
+        <location line="+380"/>
         <source>Parse: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -2538,7 +2554,7 @@ Or create them with &quot;F7&quot; hotkey for the selected float slider.</source
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../Fragmentarium/GUI/MainWindow.cpp" line="-978"/>
+        <location filename="../Fragmentarium/GUI/MainWindow.cpp" line="-1092"/>
         <source>Could not locate directory in: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -2551,7 +2567,12 @@ Or create them with &quot;F7&quot; hotkey for the selected float slider.</source
 <context>
     <name>SyntopiaCore::Logging::ListWidget</name>
     <message>
-        <location filename="../SyntopiaCore/Logging/ListWidgetLogger.h" line="+28"/>
+        <location filename="../SyntopiaCore/Logging/ListWidgetLogger.h" line="+31"/>
+        <source>Open file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Copy to Clipboard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2561,7 +2582,7 @@ Or create them with &quot;F7&quot; hotkey for the selected float slider.</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+32"/>
         <source>Copied %1 lines to clipboard</source>
         <translation type="unfinished"></translation>
     </message>

--- a/Fragmentarium-Source/Translations/Fragmentarium_nl.ts
+++ b/Fragmentarium-Source/Translations/Fragmentarium_nl.ts
@@ -34,7 +34,7 @@
 <context>
     <name>Camera2D</name>
     <message>
-        <location filename="../Fragmentarium/GUI/CameraControl.cpp" line="+474"/>
+        <location filename="../Fragmentarium/GUI/CameraControl.cpp" line="+478"/>
         <source>Camera: Click on 2D window for key focus. See Help Menu for more.</source>
         <translation>Camera: Klik in het 2D-venster voor de focus. Zie het Help-menu voor meer informatie.</translation>
     </message>
@@ -49,7 +49,7 @@
         <translation>Kan het Zoom-interfacewidget niet vinden</translation>
     </message>
     <message>
-        <location line="+33"/>
+        <location line="+58"/>
         <location line="+6"/>
         <location line="+6"/>
         <location line="+6"/>
@@ -60,7 +60,7 @@
 <context>
     <name>Camera3D</name>
     <message>
-        <location line="-457"/>
+        <location line="-486"/>
         <source>Could not find Eye interface widget</source>
         <translation>Kan het Eye-interfacewidget niet vinden</translation>
     </message>
@@ -258,7 +258,7 @@
 <context>
     <name>Fragmentarium::GUI::ComboSlider</name>
     <message>
-        <location filename="../Fragmentarium/GUI/VariableWidget.h" line="+93"/>
+        <location filename="../Fragmentarium/GUI/VariableWidget.h" line="+104"/>
         <source>Slider Step Multiplier</source>
         <translation>Schuifstapvermenigvuldiger</translation>
     </message>
@@ -276,7 +276,7 @@
 <context>
     <name>Fragmentarium::GUI::DisplayWidget</name>
     <message>
-        <location filename="../Fragmentarium/GUI/DisplayWidget.cpp" line="+120"/>
+        <location filename="../Fragmentarium/GUI/DisplayWidget.cpp" line="+125"/>
         <source>Setting display update timer to %1 ms (max %2 FPS).</source>
         <translation>Update-timer van de display ingesteld op %1 ms (max %2 FPS).</translation>
     </message>
@@ -310,7 +310,7 @@ Geïnitialiseerd als GL_RGBA8</translation>
         <translation>Maximale textuurgrootte: %1x%1</translation>
     </message>
     <message>
-        <location line="+133"/>
+        <location line="+138"/>
         <source>Asked gpu for %1 mip-map levels.</source>
         <translation>Bij GPU %1 mip-map-levels aangevraagd.</translation>
     </message>
@@ -340,7 +340,7 @@ Geïnitialiseerd als GL_RGBA8</translation>
         <translation>Kan TexParameter-waarde niet parsen: </translation>
     </message>
     <message>
-        <location line="+158"/>
+        <location line="+176"/>
         <source>No vertex shader found!</source>
         <translation>Geen vertex shader gevonden!</translation>
     </message>
@@ -360,14 +360,13 @@ Geïnitialiseerd als GL_RGBA8</translation>
         <translation>Kon fragment shader niet aanmaken: </translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+369"/>
+        <location line="+7"/>
+        <location line="+14"/>
         <source>Fragment shader compiled with warnings: </source>
         <translation>Fragment shader aangemaakt met waarschuwingen: </translation>
     </message>
     <message>
-        <location line="+1050"/>
+        <location line="+1464"/>
         <source>Frame:%1/%2 Time:%3</source>
         <translation>Omlijsting:%1/%2 Tijd:%3</translation>
     </message>
@@ -377,13 +376,13 @@ Geïnitialiseerd als GL_RGBA8</translation>
         <translation>&lt;table width=&quot;100%&quot;&gt;             &lt;tr&gt;&lt;td&gt;Totaal&lt;/td&gt;&lt;td align=&quot;center&quot;&gt;%1&lt;/td&gt;&lt;td&gt;Uiteindelijke grootte: %2&lt;/td&gt;&lt;/tr&gt;            &lt;tr&gt;&lt;td&gt;Huidige&lt;/td&gt;&lt;td align=&quot;center&quot;&gt;Tegel: %3&lt;/td&gt;&lt;td&gt;Sub: %4&lt;/td&gt;&lt;/tr&gt;            &lt;tr&gt;&lt;td&gt;Gem sec/tegel&lt;/td&gt;&lt;td align=&quot;center&quot;&gt;%5&lt;/td&gt;&lt;td&gt;ETA: %6&lt;/td&gt;&lt;/tr&gt;            &lt;/table&gt;</translation>
     </message>
     <message>
-        <location line="-1444"/>
-        <location line="+367"/>
+        <location line="-1491"/>
+        <location line="+365"/>
         <source>Could not bind shaders: </source>
         <translation>Kan shaders niet verbinden: </translation>
     </message>
     <message>
-        <location line="-345"/>
+        <location line="-343"/>
         <source>Trying to use a backbuffer, but no bufferType set.</source>
         <translation>Poging tot gebruik van backbuffer, maar geen bufferType ingesteld.</translation>
     </message>
@@ -403,7 +402,7 @@ Geïnitialiseerd als GL_RGBA8</translation>
         <translation>Exrloader heeft EXR-afbeelding gevonden: %1 is niet compleet</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+139"/>
         <source>Not a valid texture: </source>
         <translation>Geen geldige textuur: </translation>
     </message>
@@ -424,11 +423,13 @@ Geïnitialiseerd als GL_RGBA8</translation>
     </message>
     <message>
         <location line="+6"/>
+        <location line="+13"/>
         <source>Buffer fragment shader compiled with warnings: </source>
         <translation>Buffer fragment shader aangemaakt met waarschuwingen: </translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-373"/>
+        <location line="+366"/>
         <source>Could not link buffershader: </source>
         <translation>Kan buffer shader niet linken: </translation>
     </message>
@@ -438,7 +439,7 @@ Geïnitialiseerd als GL_RGBA8</translation>
         <translation>FBO Incompleet Fout!</translation>
     </message>
     <message>
-        <location line="+677"/>
+        <location line="+723"/>
         <source>Non valid FBO - previewBuffer</source>
         <translation>Ongeldige FBO - previewBuffer</translation>
     </message>
@@ -458,7 +459,7 @@ Geïnitialiseerd als GL_RGBA8</translation>
         <translation>PREVIEWBUFFER MISLUKT!</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+61"/>
         <source>Failed to bind FBO</source>
         <translation>Kan FBO niet verbinden</translation>
     </message>
@@ -473,12 +474,12 @@ Geïnitialiseerd als GL_RGBA8</translation>
         <translation>Kan target buffer niet verbinden</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-48"/>
         <source>No front buffer sampler found in buffer shader. This doesn&apos;t make sense.</source>
         <translation>Geen frontbuffer-sampler gevonden in buffershader. Dit is vreemd.</translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+93"/>
         <source>Failed to release target buffer</source>
         <translation>Kon target buffer niet vrijgeven</translation>
     </message>
@@ -496,12 +497,11 @@ Geïnitialiseerd als GL_RGBA8</translation>
         <translation>Kon hiresBuffer FBO niet vrijgeven</translation>
     </message>
     <message>
-        <location line="-1482"/>
         <source>Could not link vertex + fragment shader: </source>
-        <translation>Kan vertex + fragmentshader niet koppelen: </translation>
+        <translation type="vanished">Kan vertex + fragmentshader niet koppelen: </translation>
     </message>
     <message>
-        <location line="+274"/>
+        <location line="-1251"/>
         <source>Unused sampler uniform: </source>
         <translation>Ongebruikt monstertrekkeruniform: </translation>
     </message>
@@ -511,7 +511,7 @@ Geïnitialiseerd als GL_RGBA8</translation>
         <translation>Geen shader-hoekpuntshader gevonden!</translation>
     </message>
     <message>
-        <location line="+1011"/>
+        <location line="+1054"/>
         <location line="+39"/>
         <source>Failed to bind previewBuffer FBO</source>
         <translation>Kon previewBuffer FBO niet verbinden</translation>
@@ -533,7 +533,7 @@ Geïnitialiseerd als GL_RGBA8</translation>
         <translation>[%1x%2] Aspect=%3</translation>
     </message>
     <message>
-        <location line="+250"/>
+        <location line="+251"/>
         <source>Fix me</source>
         <translation>Los op</translation>
     </message>
@@ -551,7 +551,7 @@ Geïnitialiseerd als GL_RGBA8</translation>
 <context>
     <name>Fragmentarium::GUI::MainWindow</name>
     <message>
-        <location filename="../Fragmentarium/GUI/MainWindow.cpp" line="+115"/>
+        <location filename="../Fragmentarium/GUI/MainWindow.cpp" line="+125"/>
         <source>Host Preprocessor Commands</source>
         <translation>Host Preprocessor Commandos</translation>
     </message>
@@ -590,12 +590,12 @@ en opslaan in bestand voor afsluiting.
     </message>
     <message>
         <location line="+35"/>
-        <location line="+2683"/>
+        <location line="+2700"/>
         <source>Unsaved changes</source>
         <translation>Onopgeslagen veranderingen</translation>
     </message>
     <message>
-        <location line="-2619"/>
+        <location line="-2636"/>
         <source>Add Preset</source>
         <translation>Preset toevoegen</translation>
     </message>
@@ -626,24 +626,24 @@ en opslaan in bestand voor afsluiting.
     </message>
     <message>
         <location line="+7"/>
-        <location line="+72"/>
+        <location line="+70"/>
         <source>Fragment Source (*.frag);;All Files (*.*)</source>
         <translation>Fragment-bron (*.frag);;Alle bestanden (*.*)</translation>
     </message>
     <message>
         <location line="-31"/>
-        <location line="+1508"/>
+        <location line="+1530"/>
         <source>Set combobox to &apos;custom-size&apos; to apply size.</source>
         <translation>Stel de combobox in op &apos;custom-size&apos; om de grootte toe te passen.</translation>
     </message>
     <message>
-        <location line="-1499"/>
+        <location line="-1521"/>
         <location line="+16"/>
-        <location line="+928"/>
-        <location line="+1086"/>
+        <location line="+930"/>
+        <location line="+1106"/>
         <location line="+49"/>
         <location line="+70"/>
-        <location line="+371"/>
+        <location line="+368"/>
         <location line="+167"/>
         <location line="+10"/>
         <location line="+10"/>
@@ -654,25 +654,24 @@ en opslaan in bestand voor afsluiting.
         <translation>Geen open tab</translation>
     </message>
     <message>
-        <location line="-2909"/>
-        <location line="+1396"/>
-        <location line="+1734"/>
+        <location line="-2928"/>
+        <location line="+1418"/>
+        <location line="+1732"/>
         <source>Save As</source>
         <translation>Opslaan als</translation>
     </message>
     <message>
-        <location line="-3100"/>
+        <location line="-3120"/>
         <source>&lt;h1&gt;Fragmentarium&lt;/h1&gt;&lt;p&gt;Version %1. &lt;/p&gt;</source>
         <translation>&lt;h1&gt;Fragmentarium&lt;/h1&gt;&lt;p&gt;Versie %1. &lt;/p&gt;</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;p&gt;An integrated environment for exploring GPU pixel graphics. &lt;/p&gt;&lt;p&gt;Created by Mikael Hvidtfeldt Christensen.&lt;br /&gt;Licensed and distributed under the LPGL or GPL license.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Notice&lt;/b&gt;: some fragment (GLSL) shaders are copyright by other authors, and may carry other licenses. Please check the fragment file header before redistributing.&lt;h1&gt;Acknowledgement&lt;/h1&gt;&lt;p&gt;Much of the inspiration and formulas for Fragmentarium came from the community at &lt;a href=http://www.fractalforums.com&gt;FractalForums.com&lt;/a&gt;, including Tom Beddard, Jan Kadlec, Iñigo Quilez, Buddhi, Jesse, and others. Special thanks goes out to Knighty and Kali for their great fragments. All fragments should include information about their origins - please notify me, if I made any mis-attributions.&lt;/p&gt;&lt;p&gt;The icons used are part of the &lt;a href=&quot;http://www.everaldo.com/crystal/&quot;&gt;Everaldo: Crystal&lt;/a&gt; project. &lt;/p&gt;&lt;p&gt;Fragmentarium is built using the &lt;a href=&quot;http://trolltech.com/developer/downloads/qt/index&quot;&gt;Qt cross-platform GUI framework&lt;/a&gt;. &lt;/p&gt;&lt;/p&gt;&lt;p&gt;&lt;table cellspacing=20&gt;&lt;th colspan=2 align=left&gt;Translations by Fractal Forums users&lt;/th&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;SCORPION&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;Crist-JRoger&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;German&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Dutch&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/p&gt;</source>
         <oldsource>&lt;p&gt;An integrated environment for exploring GPU pixel graphics. &lt;/p&gt;&lt;p&gt;Created by Mikael Hvidtfeldt Christensen.&lt;br /&gt;Licensed and distributed under the LPGL or GPL license.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Notice&lt;/b&gt;: some fragment (GLSL) shaders are copyright by other authors, and may carry other licenses. Please check the fragment file header before redistributing.&lt;h1&gt;Acknowledgement&lt;/h1&gt;&lt;p&gt;Much of the inspiration and formulas for Fragmentarium came from the community at &lt;a href=http://www.fractalforums.com&gt;FractalForums.com&lt;/a&gt;, including Tom Beddard, Jan Kadlec, IÃ±igo Quilez, Buddhi, Jesse, and others. Special thanks goes out to Knighty and Kali for their great fragments. All fragments should include information about their origins - please notify me, if I made any mis-attributions.&lt;/p&gt;&lt;p&gt;The icons used are part of the &lt;a href=&quot;http://www.everaldo.com/crystal/&quot;&gt;Everaldo: Crystal&lt;/a&gt; project. &lt;/p&gt;&lt;p&gt;Fragmentarium is built using the &lt;a href=&quot;http://trolltech.com/developer/downloads/qt/index&quot;&gt;Qt cross-platform GUI framework&lt;/a&gt;. &lt;/p&gt;&lt;/p&gt;&lt;p&gt;&lt;table cellspacing=20&gt;&lt;th colspan=2 align=left&gt;Translations by Fractal Forums users&lt;/th&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;SCORPION&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;Crist-JRoger&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;German&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Dutch&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/p&gt;</oldsource>
-        <translation>&lt;p&gt;Een geïntegreerde omgeving voor het verkennen van pixel-graphics. &lt;/p&gt;&lt;p&gt;Door Mikael Hvidtfeldt Christensen.&lt;br /&gt;Licentie en verspreiding onder LPGL-of GPL-licentie.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Aantekening&lt;/b&gt;: sommige fragment-(GLSL)shaders hebben copyright bij andere auteurs, en kunnen andere licenties hebben. Check alstublieft de fragment-bestandsheader voorafgaande aan verspreiding.&lt;h1&gt;Dankwoord&lt;/h1&gt;&lt;p&gt;Een groot deel van de inspiratie en formules is te danken aan de community van &lt;a href=http://www.fractalforums.com&gt;Fractal Forums&lt;/a&gt;, onder meer Tom Beddard, Jan Kadlec, Iñigo Quilez, Buddhi, Jesse, en anderen. Bijzondere dank  gaat naar Knighty en Kali  voor hun  geweldige fragments. Allefragments zouden informatie moeten bevatten over hun oorsprong - waarschuw mij alstublieft als ik daarin een verkeerde toekenning heb gedaan.&lt;/p&gt;&lt;p&gt;De gebruikte icons zijn deel van het &lt;a href=&quot;http://www.everaldo.com/crystal/&quot;&gt;Everaldo: Crystal&lt;/a&gt; project. &lt;/p&gt;&lt;p&gt;Fragmentarium is geprogrammeerd onder gebruikmaking van &lt;a href=&quot;http://trolltech.com/developer/downloads/qt/index&quot;&gt;Qt cross-platform GUI framework&lt;/a&gt;. &lt;/p&gt;&lt;/p&gt;&lt;p&gt;&lt;table cellspacing=20&gt;&lt;th colspan=2 align=left&gt;Vertalingen door Fractal Forums-gebruikers&lt;/th&gt;&lt;tr&gt;&lt;td&gt;Russiisch&lt;/td&gt;&lt;td align=center&gt;SCORPION&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Russisch&lt;/td&gt;&lt;td align=center&gt;Crist-JRoger&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Duits&lt;/td&gt;&lt;td align=center&gt;Sabine62&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Nederlands&lt;/td&gt;&lt;td align=center&gt;Sabine62&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/p&gt;</translation>
+        <translation type="vanished">&lt;p&gt;Een geïntegreerde omgeving voor het verkennen van pixel-graphics. &lt;/p&gt;&lt;p&gt;Door Mikael Hvidtfeldt Christensen.&lt;br /&gt;Licentie en verspreiding onder LPGL-of GPL-licentie.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Aantekening&lt;/b&gt;: sommige fragment-(GLSL)shaders hebben copyright bij andere auteurs, en kunnen andere licenties hebben. Check alstublieft de fragment-bestandsheader voorafgaande aan verspreiding.&lt;h1&gt;Dankwoord&lt;/h1&gt;&lt;p&gt;Een groot deel van de inspiratie en formules is te danken aan de community van &lt;a href=http://www.fractalforums.com&gt;Fractal Forums&lt;/a&gt;, onder meer Tom Beddard, Jan Kadlec, Iñigo Quilez, Buddhi, Jesse, en anderen. Bijzondere dank  gaat naar Knighty en Kali  voor hun  geweldige fragments. Allefragments zouden informatie moeten bevatten over hun oorsprong - waarschuw mij alstublieft als ik daarin een verkeerde toekenning heb gedaan.&lt;/p&gt;&lt;p&gt;De gebruikte icons zijn deel van het &lt;a href=&quot;http://www.everaldo.com/crystal/&quot;&gt;Everaldo: Crystal&lt;/a&gt; project. &lt;/p&gt;&lt;p&gt;Fragmentarium is geprogrammeerd onder gebruikmaking van &lt;a href=&quot;http://trolltech.com/developer/downloads/qt/index&quot;&gt;Qt cross-platform GUI framework&lt;/a&gt;. &lt;/p&gt;&lt;/p&gt;&lt;p&gt;&lt;table cellspacing=20&gt;&lt;th colspan=2 align=left&gt;Vertalingen door Fractal Forums-gebruikers&lt;/th&gt;&lt;tr&gt;&lt;td&gt;Russiisch&lt;/td&gt;&lt;td align=center&gt;SCORPION&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Russisch&lt;/td&gt;&lt;td align=center&gt;Crist-JRoger&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Duits&lt;/td&gt;&lt;td align=center&gt;Sabine62&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Nederlands&lt;/td&gt;&lt;td align=center&gt;Sabine62&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="+22"/>
         <source>About Fragmentarium</source>
         <translation>Over Fragmentarium</translation>
     </message>
@@ -707,7 +706,7 @@ en opslaan in bestand voor afsluiting.
         <translation>Log</translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+19"/>
         <source>Variable Editor (uniforms)</source>
         <translation>Variabelen-editor (uniforms)</translation>
     </message>
@@ -743,14 +742,14 @@ Deze optie kan weer worden ingeschakeld in Voorkeuren</translation>
         <translation>Autorun inschakelen</translation>
     </message>
     <message>
-        <location line="+676"/>
+        <location line="+690"/>
         <source>is too large!
 Must be less than 32769x32769</source>
         <translation>is te groot!
 Moet minder zijn dan 32769x32769</translation>
     </message>
     <message>
-        <location line="+887"/>
+        <location line="+893"/>
         <source>Reloaded file: %1</source>
         <translation>Reloaded-bestand: %1</translation>
     </message>
@@ -792,7 +791,7 @@ Moet minder zijn dan 32769x32769</translation>
         <translation>Beschikbare afbeeldingsformaten: </translation>
     </message>
     <message>
-        <location line="+231"/>
+        <location line="+228"/>
         <source>// Cannot read file %1:
 // %2
 </source>
@@ -816,7 +815,7 @@ Sluit dit tabblad zonder wijzigingen op te slaan?</translation>
         <translation>Kan OpenGl-functies niet herkennen die benodigd zijn om de AsmBrowser in te kunnen schakelen</translation>
     </message>
     <message>
-        <location line="-2319"/>
+        <location line="-2336"/>
         <source>This is your first run of Fragmentarium.
 Please read this:
 
@@ -880,12 +879,12 @@ l
     </message>
     <message>
         <location line="+8"/>
-        <location line="+2626"/>
+        <location line="+2644"/>
         <source>&amp;Save</source>
         <translation>Op&amp;slaan</translation>
     </message>
     <message>
-        <location line="-2625"/>
+        <location line="-2643"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
@@ -1038,7 +1037,7 @@ Continue and loose changes?</source>
 Doorgaan en verliezen veranderen?</translation>
     </message>
     <message>
-        <location line="+306"/>
+        <location line="+304"/>
         <source>&lt;p&gt;Notice: the 3D view must have keyboard focus!&lt;/p&gt;&lt;h2&gt;2D&lt;/h2&gt;&lt;p&gt;&lt;ul&gt;&lt;li&gt;Left mousebutton: translate center.&lt;/li&gt;&lt;li&gt;Right mousebutton: zoom.&lt;/li&gt;&lt;li&gt;Wheel: zoom&lt;/li&gt;&lt;li&gt;A/D: left/right&lt;/li&gt;&lt;li&gt;W/S: up/down&lt;/li&gt;&lt;li&gt;Q/E: zoom in/out&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;h2&gt;3D&lt;/h2&gt;&lt;p&gt;&lt;ul&gt;&lt;li&gt;Shift+Right mouse button: shows menus when in fullscreen mode.&lt;/li&gt;&lt;li&gt;Left mouse button: change camera direction.&lt;/li&gt;&lt;li&gt;Right mouse button: move camera in screen plane.&lt;/li&gt;&lt;li&gt;Left+Right mouse button: zoom.&lt;/li&gt;&lt;li&gt;Shift+Left mouse button: rotate object (around origin).&lt;/li&gt;&lt;li&gt;Shift+Alt+Left mouse button: rotate object (around target).&lt;/li&gt;&lt;li&gt;Shift+Tilde (~) resets the view to look through origin (0,0,0)&lt;/li&gt;&lt;li&gt;Wheel: Move forward/backward&lt;/li&gt;&lt;li&gt;W/S: move forward/back.&lt;/li&gt;&lt;li&gt;A/D: move left/right.&lt;/li&gt;&lt;li&gt;Q/E: roll&lt;/li&gt;&lt;li&gt;1/3: increase/decrease step size x2&lt;/li&gt;&lt;li&gt;2: increase/decrease step size x10&lt;/li&gt;&lt;li&gt;Shift+Wheel: change step size&lt;/li&gt;&lt;li&gt;T/G: move up/down.&lt;/li&gt;&lt;li&gt;R/F: yaw&lt;/li&gt;&lt;li&gt;Y/H: pitch&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;h2&gt;Sliders&lt;/h2&gt;&lt;p&gt;When a (float) slider recieves a Right Mouse Button Click it opens an input dialog to set the step size.&lt;br&gt;&lt;b&gt;F7 Key&lt;/b&gt; opens the easing curve editor for the currently selected slider.&lt;/p&gt;</source>
         <translation>&lt;p&gt; Opmerking: de 3D-weergave moet toetsenbordfocus hebben! &lt;/p&gt; &lt;h2&gt; 2D &lt;/h2&gt; &lt;p&gt; &lt;ul&gt; &lt;li&gt; Linkermuisknop: Vertaal midden. &lt;/li&gt; &lt;li&gt; Rechter muisknop: zoom. &lt;/li&gt; &lt;li&gt; Wiel: zoom &lt;/li&gt; &lt;li&gt; A / D: links / rechts &lt;/li&gt; &lt;li&gt; W / S: omhoog / omlaag &lt;/li&gt; &lt;li&gt; Q / E : inzoomen / uitzoomen &lt;/li&gt; &lt;/ul&gt; &lt;/p&gt; &lt;h2&gt; 3D &lt;/h2&gt; &lt;p&gt; &lt;ul&gt; &lt;li&gt; Shift + rechtermuisknop: toont menu&apos;s in de modus voor volledig scherm. &lt;/li &gt; &lt;li&gt; Linkermuisknop: wijzig de camerarichting. &lt;/li&gt; &lt;li&gt; Rechter muisknop: verplaats de camera in het schermvlak. &lt;/li&gt; &lt;li&gt; Linkermuisknop + zoomknop &lt;/li&gt; &lt;li &gt; Shift + linkermuisknop: object roteren (rond oorsprong). &lt;/Li&gt; &lt;li&gt; Shift + Alt + linkermuisknop: object roteren (rond doel). &lt;/Li&gt; &lt;li&gt; Shift + Tilde (~) stelt opnieuw in het uitzicht om door de oorsprong te kijken (0,0,0) &lt;/li&gt; &lt;li&gt; Wiel: vooruit / achteruit gaan &lt;/li&gt; &lt;li&gt; W / S: vooruit / achteruit gaan. &lt;/li&gt; &lt;li&gt; A / D: beweeg links / rechts. &lt;/Li&gt; &lt;li&gt; Q / E: rol &lt;/li&gt; &lt;li&gt; 1/3: verhoog / verlaag stapgrootte x2 &lt;/li&gt; &lt;li&gt; 2: verhoog / verlaag stap size x10 &lt;/li&gt; &lt;li&gt; Shift + Wheel: verander stapgrootte &lt;/li&gt; &lt;li&gt; T / G: beweeg omhoog / omlaag. &lt;/li&gt; &lt;li&gt; R / F: yaw &lt;/li&gt; &lt;li &gt; Y / H: toonhoogte &lt;/li&gt; &lt;/ul&gt; &lt;/p&gt; &lt;h2&gt; Sliders &lt;/h2&gt; &lt;p&gt; Wanneer een (float) -schuifregelaar een rechtermuisknop krijgt Klik op om een ​​invoerdialoog te openen om de stapgrootte in te stellen. &lt;br&gt; &lt;b&gt; F7-toets &lt;/b&gt; opent de easing-curve editor voor de momenteel geselecteerde schuifregelaar. &lt;/p&gt;</translation>
     </message>
@@ -1048,7 +1047,7 @@ Doorgaan en verliezen veranderen?</translation>
         <translation>&lt;h2&gt; Herschrijft opdrachten voor afbeeldingen en animatiedialogen &lt;/ h2&gt; &lt;p&gt; &lt;ul&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setAnimationLength (int); &lt;/ b&gt; &lt;/ li&gt; Stelt de totale duur van de animatie in seconden in. &lt;/ p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setTileWidth (int); &lt;/ b&gt; &lt;/ li&gt; &lt;li&gt; &lt;b&gt; void setTileHeight (int); &lt;/ b&gt; &lt;/ li&gt; stelt de tegel in breedte en hoogte. &lt;/ p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setTileMax (int); &lt;/ b&gt; &lt;/ li&gt; Stelt het aantal rij- en kolomtegels in, deze waarde in het kwadraat = totale tegels. &lt;/ p &gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setSubFrames (int); &lt;/ b&gt; &lt;/ li&gt; Stelt het aantal te verzamelen frames in. &lt;/ p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setOutputBaseFileName (String) ; &lt;/ b&gt; &lt;/ li&gt; Stelt de bestandsnaam in voor de opgeslagen afbeelding, &lt;br&gt; als het script de volledige controle heeft, moet dit door het script voor elk frame worden ingesteld, en - als animatie frag bestandinstellingen, keyframes enz. gebruikt, dan hoeft dit slechts één keer te worden ingesteld om basename te gebruiken en voegt Fragmentarium een ​​met 5 opgevulde index toe. &lt;/ p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setFps (int); &lt;/ b&gt; &lt;/ li&gt; Stelt de frames per seconde voor rendering. &lt;/ p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setStartFrame (int); &lt;/ b&gt; &lt;/ li&gt; Stelt het startframe-nummer in voor het weergeven van een reeks frames. &lt;/ p&gt; &lt; p&gt; &lt;li&gt; &lt;b&gt; void setEndFrame (int); &lt;/ b&gt; &lt;/ li&gt; Stelt het eindraamnummer in voor het renderen van een reeks frames. &lt;/ p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setAnimation ( bool); &lt;/ b&gt; &lt;/ li&gt; FALSE zet alleen de animatie van het script in. &lt;br&gt; TRUE maakt controle mogelijk vanuit hoofdframes en verlichte curven. &lt;/ p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setPreview (bool); &lt;/ b&gt; &lt;/ li&gt; TRUE geeft een voorbeeld van frames in een venster op het bureaublad in plaats van het opslaan van afbeeldingsbestanden. &lt;br&gt; WAARSCHUWING !!! dit opent een venster VOOR ELK FRAME en sluit het wanneer het volgende klaar is voor weergave. &lt;/ p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setAutoSave (bool); &lt;/ b&gt; &lt;/ li&gt; TRUE zal opslaan bestanden in de submap. &lt;br&gt; FALSE gebruikt het pad ingesteld door setOutputBaseFileName (String) &lt;/ p&gt; &lt;p&gt; &lt;li&gt; &lt;b&gt; void setUniqueID (bool); &lt;/ b&gt; &lt;/ li&gt; doet hetzelfde als &quot;Voeg een unieke ID toe aan de bestandsnaam&quot; in de HiResolution- en animatiedialoog. &lt;br&gt; &lt;/ p&gt; &lt;/ ul&gt; &lt;/ p&gt;</translation>
     </message>
     <message>
-        <location line="+234"/>
+        <location line="+236"/>
         <source>EXR &amp;Tools</source>
         <translation>EXR &amp;Tools</translation>
     </message>
@@ -1334,12 +1333,17 @@ Doorgaan en verliezen veranderen?</translation>
     </message>
     <message>
         <location line="-986"/>
-        <location line="+2683"/>
+        <location line="+2700"/>
         <source>Continue</source>
         <translation>Doorgaan met</translation>
     </message>
     <message>
-        <location line="-1738"/>
+        <location line="-2499"/>
+        <source>&lt;p&gt;An integrated environment for exploring GPU pixel graphics. &lt;/p&gt;&lt;p&gt;Created by Mikael Hvidtfeldt Christensen.&lt;br /&gt;Licensed and distributed under the LPGL or GPL license.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Notice&lt;/b&gt;: some fragment (GLSL) shaders are copyright by other authors, and may carry other licenses. Please check the fragment file header before redistributing.&lt;h1&gt;Acknowledgement&lt;/h1&gt;&lt;p&gt;Much of the inspiration and formulas for Fragmentarium came from the community at &lt;a href=http://www.fractalforums.com&gt;FractalForums.com&lt;/a&gt;, including Tom Beddard, Jan Kadlec, Iñigo Quilez, Buddhi, Jesse, and others. Special thanks goes out to Knighty and Kali for their great fragments and claude for all his help with improvements. All fragments should include information about their origins - please notify me, if I made any mis-attributions.&lt;/p&gt;&lt;p&gt;The icons used are part of the &lt;a href=&quot;http://www.everaldo.com/crystal/&quot;&gt;Everaldo: Crystal&lt;/a&gt; project. &lt;/p&gt;&lt;p&gt;Fragmentarium is built using the &lt;a href=&quot;http://trolltech.com/developer/downloads/qt/index&quot;&gt;Qt cross-platform GUI framework&lt;/a&gt;. &lt;/p&gt;&lt;/p&gt;&lt;p&gt;&lt;table cellspacing=20&gt;&lt;th colspan=2 align=left&gt;Translations by Fractal Forums users&lt;/th&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;SCORPION&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;Crist-JRoger&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;German&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Dutch&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Een geïntegreerde omgeving voor het verkennen van pixel-graphics. &lt;/p&gt;&lt;p&gt;Door Mikael Hvidtfeldt Christensen.&lt;br /&gt;Licentie en verspreiding onder LPGL-of GPL-licentie.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Aantekening&lt;/b&gt;: sommige fragment-(GLSL)shaders hebben copyright bij andere auteurs, en kunnen andere licenties hebben. Check alstublieft de fragment-bestandsheader voorafgaande aan verspreiding.&lt;h1&gt;Dankwoord&lt;/h1&gt;&lt;p&gt;Een groot deel van de inspiratie en formules is te danken aan de community van &lt;a href=http://www.fractalforums.com&gt;Fractal Forums&lt;/a&gt;, onder meer Tom Beddard, Jan Kadlec, Iñigo Quilez, Buddhi, Jesse, en anderen. Bijzondere dank  gaat naar Knighty en Kali  voor hun  geweldige fragments en claude voor al zijn hulp bij verbeteringen.. Allefragments zouden informatie moeten bevatten over hun oorsprong - waarschuw mij alstublieft als ik daarin een verkeerde toekenning heb gedaan.&lt;/p&gt;&lt;p&gt;De gebruikte icons zijn deel van het &lt;a href=&quot;http://www.everaldo.com/crystal/&quot;&gt;Everaldo: Crystal&lt;/a&gt; project. &lt;/p&gt;&lt;p&gt;Fragmentarium is geprogrammeerd onder gebruikmaking van &lt;a href=&quot;http://trolltech.com/developer/downloads/qt/index&quot;&gt;Qt cross-platform GUI framework&lt;/a&gt;. &lt;/p&gt;&lt;/p&gt;&lt;p&gt;&lt;table cellspacing=20&gt;&lt;th colspan=2 align=left&gt;Vertalingen door Fractal Forums-gebruikers&lt;/th&gt;&lt;tr&gt;&lt;td&gt;Russiisch&lt;/td&gt;&lt;td align=center&gt;SCORPION&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Russisch&lt;/td&gt;&lt;td align=center&gt;Crist-JRoger&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Duits&lt;/td&gt;&lt;td align=center&gt;Sabine62&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Nederlands&lt;/td&gt;&lt;td align=center&gt;Sabine62&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location line="+744"/>
         <source>Windows</source>
         <translation>ramen</translation>
     </message>
@@ -1364,28 +1368,34 @@ Doorgaan en verliezen veranderen?</translation>
         <translation>// Aangemaakt: </translation>
     </message>
     <message>
-        <location line="+26"/>
-        <location line="+8"/>
+        <location line="+15"/>
+        <source>Do you want to use it? &lt;br&gt;&lt;br&gt;This will overwrite any existing files!</source>
+        <translation>Wil je het gebruiken? &lt;br&gt; &lt;br&gt; Hiermee worden bestaande bestanden overschreven!</translation>
+    </message>
+    <message>
         <location line="+16"/>
-        <location line="+420"/>
+        <location line="+10"/>
+        <location line="+17"/>
+        <location line="+5"/>
+        <location line="+427"/>
         <location line="+19"/>
         <location line="+514"/>
         <location line="+72"/>
-        <location line="+1121"/>
+        <location line="+1119"/>
         <location line="+22"/>
         <source>Fragmentarium</source>
         <translation>Fragmentarium</translation>
     </message>
     <message>
-        <location line="-2192"/>
+        <location line="-2205"/>
         <source>Could not create directory %1:
 .</source>
         <translation>Kan folder niet aanmaken %1:
 .</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+436"/>
+        <location line="+10"/>
+        <location line="+449"/>
         <location line="+606"/>
         <source>Cannot write file %1:
 %2.</source>
@@ -1393,12 +1403,12 @@ Doorgaan en verliezen veranderen?</translation>
 %2.</translation>
     </message>
     <message>
-        <location line="-1036"/>
+        <location line="-1049"/>
         <source>Saved fragment + settings as: </source>
         <translation>Fragment en instellingen opgeslagen als: </translation>
     </message>
     <message>
-        <location line="+10"/>
+        <location line="+16"/>
         <source>Could not copy dependency:
 &apos;%1&apos; to 
 &apos;%2&apos;.</source>
@@ -1407,7 +1417,7 @@ Doorgaan en verliezen veranderen?</translation>
 &apos;%2&apos;.</translation>
     </message>
     <message>
-        <location line="+33"/>
+        <location line="+34"/>
         <source>Do you want to try again?</source>
         <translation>Wilt u het nog een keer proberen?</translation>
     </message>
@@ -1422,7 +1432,7 @@ Doorgaan en verliezen veranderen?</translation>
         <translation>Afbreken</translation>
     </message>
     <message>
-        <location line="+276"/>
+        <location line="+282"/>
         <location line="+41"/>
         <source>Saved file : </source>
         <translation>Opgeslagen bestand: </translation>
@@ -1466,14 +1476,15 @@ Doorgaan en verliezen veranderen?</translation>
     <message>
         <location line="+13"/>
         <location line="+473"/>
-        <location line="+1257"/>
+        <location line="+1255"/>
+        <location line="+199"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Kan bestand niet lezen %1:
 %2.</translation>
     </message>
     <message>
-        <location line="-1723"/>
+        <location line="-1920"/>
         <source>Settings loaded from file</source>
         <translation>Instellingen geladen uit bestand</translation>
     </message>
@@ -1668,7 +1679,7 @@ Wil je het opnieuw laden?</translation>
         <translation>Geen uitvoerbaar fragment.</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+55"/>
         <source>Compiled script in %1 ms.</source>
         <translation>Script gecompileerd in %1 ms.</translation>
     </message>
@@ -1694,11 +1705,12 @@ Wil je het opnieuw laden?</translation>
     </message>
     <message>
         <location line="+42"/>
+        <location line="+971"/>
         <source>Loaded file: %1</source>
         <translation>Bestand geladen: %1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="-963"/>
         <source>Unnamed</source>
         <translation>Naamloos</translation>
     </message>
@@ -1713,29 +1725,54 @@ Wil je het opnieuw laden?</translation>
         <translation>Wanneer de preset vergrendelde variabelen verandert is &quot;Build&quot; opnieuw vereist.</translation>
     </message>
     <message>
-        <source>There are unsaved changes.%1
-Continue will discard changes.</source>
-        <translation type="vanished">Er zijn tabbladen met niet-opgeslagen wijzigingen.%1
-Doorgaan en verliezen veranderen.</translation>
-    </message>
-    <message>
         <source>
 To keep Easing curves you must
 add a preset named &quot;Range&quot;
 and save before closing!</source>
-        <translation type="vanished">
+        <translation type="obsolete">
 U moet dit doen om Verlichtingscurven te behouden
 een voorinstelling toevoegen met de naam &quot;Bereik&quot;
 en bespaar voor sluitingstijd!</translation>
     </message>
     <message>
-        <location line="-2647"/>
-        <location line="+2683"/>
+        <source>Cannot read file %1:
+%2
+</source>
+        <translation type="obsolete">Kan bestand niet lezen %1:
+%2. {1:?} {2
+?}</translation>
+    </message>
+    <message>
+        <source>There are unsaved changes.%1
+Continue will discard changes.</source>
+        <translation type="obsolete">Er zijn tabbladen met niet-opgeslagen wijzigingen.%1
+Doorgaan en verliezen veranderen.</translation>
+    </message>
+    <message>
+        <location line="+920"/>
+        <source>CMD Script (*.fqs);;All Files (*.*)</source>
+        <translation>Cmd Script (*.fqs);;Alle bestanden (*.*)</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Bind CMD script to F6 key</source>
+        <translation>Bindend opdrachtscript aan F6-toets</translation>
+    </message>
+    <message>
+        <location line="-3586"/>
+        <location line="+2700"/>
         <source>Cancel</source>
         <translation>Afbreken</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="-1531"/>
+        <source>Could not remove dependency:
+&apos;%1&apos;</source>
+        <translation>Kan afhankelijkheid niet verwijderen:
+&apos;%1&apos;</translation>
+    </message>
+    <message>
+        <location line="+1575"/>
         <location line="+10"/>
         <location line="+10"/>
         <source>Launching web browser...</source>
@@ -1810,7 +1847,7 @@ en bespaar voor sluitingstijd!</translation>
         <translation>Moet een .frag- of .fragparams-bestand zijn.</translation>
     </message>
     <message>
-        <location line="+338"/>
+        <location line="+339"/>
         <source>#endpreset not found!</source>
         <translation>#endpreset niet gevonden!</translation>
     </message>
@@ -1859,6 +1896,7 @@ en bespaar voor sluitingstijd!</translation>
     </message>
     <message>
         <location line="+65"/>
+        <location line="+113"/>
         <source>Error %1 at line %2</source>
         <translation>Fout %1 in regel %2</translation>
     </message>
@@ -1932,7 +1970,7 @@ en bespaar voor sluitingstijd!</translation>
 <context>
     <name>Fragmentarium::GUI::SamplerWidget</name>
     <message>
-        <location filename="../Fragmentarium/GUI/VariableWidget.cpp" line="+765"/>
+        <location filename="../Fragmentarium/GUI/VariableWidget.cpp" line="+781"/>
         <source>Select a Texture</source>
         <translation>Kies textuur</translation>
     </message>
@@ -2025,22 +2063,22 @@ Of maak ze met de snelkoppeling \ &quot;F7 \&quot; voor de geselecteerde zwevend
         <translation> gekopiëerd naar het klembord</translation>
     </message>
     <message>
-        <location line="+118"/>
+        <location line="+119"/>
         <source>%1 locked variables: %2</source>
         <translation>%1 vergrendelde variabelen: %2</translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+141"/>
         <source>Unsupported parameter</source>
         <translation>Onondersteunde parameter</translation>
     </message>
     <message>
-        <location line="+144"/>
+        <location line="+166"/>
         <source>Expected a key value pair, found: </source>
         <translation>Verwacht keywaardenpaar, gevonden: </translation>
     </message>
     <message>
-        <location line="+21"/>
+        <location line="+23"/>
         <source>Could not find: </source>
         <translation>Kon niet vinden: </translation>
     </message>
@@ -2573,7 +2611,7 @@ Of maak ze met de snelkoppeling \ &quot;F7 \&quot; voor de geselecteerde zwevend
 <context>
     <name>Preprocessor</name>
     <message>
-        <location filename="../Fragmentarium/Parser/Preprocessor.cpp" line="+156"/>
+        <location filename="../Fragmentarium/Parser/Preprocessor.cpp" line="+253"/>
         <source>Including file: </source>
         <translation>Toegevoegd bestand: </translation>
     </message>
@@ -2583,7 +2621,7 @@ Of maak ze met de snelkoppeling \ &quot;F7 \&quot; voor de geselecteerde zwevend
         <translation>Toegevoegde buffershader: </translation>
     </message>
     <message>
-        <location line="+374"/>
+        <location line="+380"/>
         <source>Parse: </source>
         <translation>Parse: </translation>
     </message>
@@ -2591,7 +2629,7 @@ Of maak ze met de snelkoppeling \ &quot;F7 \&quot; voor de geselecteerde zwevend
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../Fragmentarium/GUI/MainWindow.cpp" line="-978"/>
+        <location filename="../Fragmentarium/GUI/MainWindow.cpp" line="-1092"/>
         <source>Could not locate directory in: </source>
         <translation>Kan folder niet vinden in: </translation>
     </message>
@@ -2604,7 +2642,12 @@ Of maak ze met de snelkoppeling \ &quot;F7 \&quot; voor de geselecteerde zwevend
 <context>
     <name>SyntopiaCore::Logging::ListWidget</name>
     <message>
-        <location filename="../SyntopiaCore/Logging/ListWidgetLogger.h" line="+28"/>
+        <location filename="../SyntopiaCore/Logging/ListWidgetLogger.h" line="+31"/>
+        <source>Open file</source>
+        <translation>Open bestand</translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Copy to Clipboard</source>
         <translation>Kopiëren naar klembord</translation>
     </message>
@@ -2614,7 +2657,7 @@ Of maak ze met de snelkoppeling \ &quot;F7 \&quot; voor de geselecteerde zwevend
         <translation>Wissen</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+32"/>
         <source>Copied %1 lines to clipboard</source>
         <translation>%1 regels gekopieëerd naar het klembord</translation>
     </message>

--- a/Fragmentarium-Source/Translations/Fragmentarium_ru.ts
+++ b/Fragmentarium-Source/Translations/Fragmentarium_ru.ts
@@ -34,7 +34,7 @@
 <context>
     <name>Camera2D</name>
     <message>
-        <location filename="../Fragmentarium/GUI/CameraControl.cpp" line="+474"/>
+        <location filename="../Fragmentarium/GUI/CameraControl.cpp" line="+478"/>
         <source>Camera: Click on 2D window for key focus. See Help Menu for more.</source>
         <translation>Камера: Нажмите 2D окно для управления движением с помощью клавиатуры. Для получения более подробной информации, обратитесь к меню Справка.</translation>
     </message>
@@ -49,7 +49,7 @@
         <translation>Не удалось найти интерфейс Zoom</translation>
     </message>
     <message>
-        <location line="+33"/>
+        <location line="+58"/>
         <location line="+6"/>
         <location line="+6"/>
         <location line="+6"/>
@@ -60,7 +60,7 @@
 <context>
     <name>Camera3D</name>
     <message>
-        <location line="-457"/>
+        <location line="-486"/>
         <source>Could not find Eye interface widget</source>
         <translation>Не удалось найти интерфейс Eye</translation>
     </message>
@@ -258,7 +258,7 @@
 <context>
     <name>Fragmentarium::GUI::ComboSlider</name>
     <message>
-        <location filename="../Fragmentarium/GUI/VariableWidget.h" line="+93"/>
+        <location filename="../Fragmentarium/GUI/VariableWidget.h" line="+104"/>
         <source>Slider Step Multiplier</source>
         <translation>Множитель шага слайдера</translation>
     </message>
@@ -276,7 +276,7 @@
 <context>
     <name>Fragmentarium::GUI::DisplayWidget</name>
     <message>
-        <location filename="../Fragmentarium/GUI/DisplayWidget.cpp" line="+120"/>
+        <location filename="../Fragmentarium/GUI/DisplayWidget.cpp" line="+125"/>
         <source>Setting display update timer to %1 ms (max %2 FPS).</source>
         <translation>Установка таймера обновления дисплея %1 мс ( макс %2 кадров в секунду).</translation>
     </message>
@@ -310,7 +310,7 @@ Initialized as GL_RGBA8</source>
         <translation>Максимальный размер текстуры: %1x%1</translation>
     </message>
     <message>
-        <location line="+133"/>
+        <location line="+138"/>
         <source>Asked gpu for %1 mip-map levels.</source>
         <translation>На запрос для графического процессора %1 уровней mip-map.</translation>
     </message>
@@ -340,7 +340,7 @@ Initialized as GL_RGBA8</source>
         <translation>Не удалось разобрать значение параметра текстуры: </translation>
     </message>
     <message>
-        <location line="+158"/>
+        <location line="+176"/>
         <source>No vertex shader found!</source>
         <translation>Не найдены вершинные шейдеры!</translation>
     </message>
@@ -360,14 +360,13 @@ Initialized as GL_RGBA8</source>
         <translation>Не удалось создать фрагмент-шейдер: </translation>
     </message>
     <message>
-        <location line="+9"/>
-        <location line="+16"/>
-        <location line="+369"/>
+        <location line="+7"/>
+        <location line="+14"/>
         <source>Fragment shader compiled with warnings: </source>
         <translation>Фрагмент-шейдер компилируется с предупреждениями: </translation>
     </message>
     <message>
-        <location line="+1050"/>
+        <location line="+1464"/>
         <source>Frame:%1/%2 Time:%3</source>
         <translation>Кадр:%1/%2 Время:%3</translation>
     </message>
@@ -377,13 +376,13 @@ Initialized as GL_RGBA8</source>
         <translation>&lt;table width=&quot;100%&quot;&gt;             &lt;tr&gt;&lt;td&gt;Total&lt;/td&gt;&lt;td align=&quot;center&quot;&gt;%1&lt;/td&gt;&lt;td&gt;Окончательный размер: %2&lt;/td&gt;&lt;/tr&gt;             &lt;tr&gt;&lt;td&gt;Текущий&lt;/td&gt;&lt;td align=&quot;center&quot;&gt;Плитка: %3&lt;/td&gt;&lt;td&gt;подкадр: %4&lt;/td&gt;&lt;/tr&gt;             &lt;tr&gt;&lt;td&gt;Средняя сек / плитка&lt;/td&gt;&lt;td align=&quot;center&quot;&gt;%5&lt;/td&gt;&lt;td&gt;П.в.п.: %6&lt;/td&gt;&lt;/tr&gt;             &lt;/table&gt;</translation>
     </message>
     <message>
-        <location line="-1444"/>
-        <location line="+367"/>
+        <location line="-1491"/>
+        <location line="+365"/>
         <source>Could not bind shaders: </source>
         <translation>Не удалось связать шейдеры: </translation>
     </message>
     <message>
-        <location line="-345"/>
+        <location line="-343"/>
         <source>Trying to use a backbuffer, but no bufferType set.</source>
         <translation>Попытка использовать backbuffer не того типа.</translation>
     </message>
@@ -403,7 +402,7 @@ Initialized as GL_RGBA8</source>
         <translation>EXR загрузчик найдено EXR изображение: %1 не является полным</translation>
     </message>
     <message>
-        <location line="+135"/>
+        <location line="+139"/>
         <source>Not a valid texture: </source>
         <translation>Неверная текстура: </translation>
     </message>
@@ -424,11 +423,13 @@ Initialized as GL_RGBA8</source>
     </message>
     <message>
         <location line="+6"/>
+        <location line="+13"/>
         <source>Buffer fragment shader compiled with warnings: </source>
         <translation>Буфер фрагмента шейдера скомпилирован с предупреждениями: </translation>
     </message>
     <message>
-        <location line="+12"/>
+        <location line="-373"/>
+        <location line="+366"/>
         <source>Could not link buffershader: </source>
         <translation>Не удалось привязать шейдера буфер: </translation>
     </message>
@@ -438,7 +439,7 @@ Initialized as GL_RGBA8</source>
         <translation>Неполное FBO Ошибка!</translation>
     </message>
     <message>
-        <location line="+677"/>
+        <location line="+723"/>
         <source>Non valid FBO - previewBuffer</source>
         <translation>Недействительное FBO - просмотр буфера</translation>
     </message>
@@ -458,7 +459,7 @@ Initialized as GL_RGBA8</source>
         <translation>Просмотр буфера не возможен!</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+61"/>
         <source>Failed to bind FBO</source>
         <translation>Не удалось привязать FBO</translation>
     </message>
@@ -473,12 +474,12 @@ Initialized as GL_RGBA8</source>
         <translation>Не удалось связать целевой буфер</translation>
     </message>
     <message>
-        <location line="-45"/>
+        <location line="-48"/>
         <source>No front buffer sampler found in buffer shader. This doesn&apos;t make sense.</source>
         <translation>Нет переднего буфера, образец не найден в буфере шейдера. Это не имеет смысла.</translation>
     </message>
     <message>
-        <location line="+90"/>
+        <location line="+93"/>
         <source>Failed to release target buffer</source>
         <translation>Не удалось освободить целевой буфер</translation>
     </message>
@@ -496,12 +497,11 @@ Initialized as GL_RGBA8</source>
         <translation>Не удалось освободить hiresBuffer FBO</translation>
     </message>
     <message>
-        <location line="-1482"/>
         <source>Could not link vertex + fragment shader: </source>
-        <translation>Не удалось связать вершинный шейдер с фрагментным шейдером: </translation>
+        <translation type="vanished">Не удалось связать вершинный шейдер с фрагментным шейдером: </translation>
     </message>
     <message>
-        <location line="+274"/>
+        <location line="-1251"/>
         <source>Unused sampler uniform: </source>
         <translation>Неиспользуемая равномерная переменная сэмплера: </translation>
     </message>
@@ -511,7 +511,7 @@ Initialized as GL_RGBA8</source>
         <translation>Вершинный шейдер не найден!</translation>
     </message>
     <message>
-        <location line="+1011"/>
+        <location line="+1054"/>
         <location line="+39"/>
         <source>Failed to bind previewBuffer FBO</source>
         <translation>Не удалось связать previewBuffer FBO</translation>
@@ -533,7 +533,7 @@ Initialized as GL_RGBA8</source>
         <translation>[%1x%2]Соотношение сторон=%3</translation>
     </message>
     <message>
-        <location line="+250"/>
+        <location line="+251"/>
         <source>Fix me</source>
         <translation>Поправте меня</translation>
     </message>
@@ -551,7 +551,7 @@ Initialized as GL_RGBA8</source>
 <context>
     <name>Fragmentarium::GUI::MainWindow</name>
     <message>
-        <location filename="../Fragmentarium/GUI/MainWindow.cpp" line="+115"/>
+        <location filename="../Fragmentarium/GUI/MainWindow.cpp" line="+125"/>
         <source>Host Preprocessor Commands</source>
         <translation>Команды препроцессора</translation>
     </message>
@@ -590,12 +590,12 @@ and save to file before closing.
     </message>
     <message>
         <location line="+35"/>
-        <location line="+2683"/>
+        <location line="+2700"/>
         <source>Unsaved changes</source>
         <translation>Несохраненные изменения</translation>
     </message>
     <message>
-        <location line="-2619"/>
+        <location line="-2636"/>
         <source>Add Preset</source>
         <translation>Добавить предустановку</translation>
     </message>
@@ -626,24 +626,24 @@ and save to file before closing.
     </message>
     <message>
         <location line="+7"/>
-        <location line="+72"/>
+        <location line="+70"/>
         <source>Fragment Source (*.frag);;All Files (*.*)</source>
         <translation>Источник фрагментов (*.frag);;Все файлы (*.*)</translation>
     </message>
     <message>
         <location line="-31"/>
-        <location line="+1508"/>
+        <location line="+1530"/>
         <source>Set combobox to &apos;custom-size&apos; to apply size.</source>
         <translation>Выпадающий список в &apos;Свободный размер&apos;, применить размер.</translation>
     </message>
     <message>
-        <location line="-1499"/>
+        <location line="-1521"/>
         <location line="+16"/>
-        <location line="+928"/>
-        <location line="+1086"/>
+        <location line="+930"/>
+        <location line="+1106"/>
         <location line="+49"/>
         <location line="+70"/>
-        <location line="+371"/>
+        <location line="+368"/>
         <location line="+167"/>
         <location line="+10"/>
         <location line="+10"/>
@@ -654,22 +654,21 @@ and save to file before closing.
         <translation>Нет открытых вкладок</translation>
     </message>
     <message>
-        <location line="-2909"/>
-        <location line="+1396"/>
-        <location line="+1734"/>
+        <location line="-2928"/>
+        <location line="+1418"/>
+        <location line="+1732"/>
         <source>Save As</source>
         <translation>Сохранить как</translation>
     </message>
     <message>
-        <location line="-3100"/>
+        <location line="-3120"/>
         <source>&lt;h1&gt;Fragmentarium&lt;/h1&gt;&lt;p&gt;Version %1. &lt;/p&gt;</source>
         <translation>&lt;h1&gt;Фрагментариум&lt;/h1&gt;&lt;p&gt;версии %1. &lt;/p&gt;</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;p&gt;An integrated environment for exploring GPU pixel graphics. &lt;/p&gt;&lt;p&gt;Created by Mikael Hvidtfeldt Christensen.&lt;br /&gt;Licensed and distributed under the LPGL or GPL license.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Notice&lt;/b&gt;: some fragment (GLSL) shaders are copyright by other authors, and may carry other licenses. Please check the fragment file header before redistributing.&lt;h1&gt;Acknowledgement&lt;/h1&gt;&lt;p&gt;Much of the inspiration and formulas for Fragmentarium came from the community at &lt;a href=http://www.fractalforums.com&gt;FractalForums.com&lt;/a&gt;, including Tom Beddard, Jan Kadlec, Iñigo Quilez, Buddhi, Jesse, and others. Special thanks goes out to Knighty and Kali for their great fragments. All fragments should include information about their origins - please notify me, if I made any mis-attributions.&lt;/p&gt;&lt;p&gt;The icons used are part of the &lt;a href=&quot;http://www.everaldo.com/crystal/&quot;&gt;Everaldo: Crystal&lt;/a&gt; project. &lt;/p&gt;&lt;p&gt;Fragmentarium is built using the &lt;a href=&quot;http://trolltech.com/developer/downloads/qt/index&quot;&gt;Qt cross-platform GUI framework&lt;/a&gt;. &lt;/p&gt;&lt;/p&gt;&lt;p&gt;&lt;table cellspacing=20&gt;&lt;th colspan=2 align=left&gt;Translations by Fractal Forums users&lt;/th&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;SCORPION&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;Crist-JRoger&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;German&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Dutch&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/p&gt;</source>
         <oldsource>&lt;p&gt;An integrated environment for exploring GPU pixel graphics. &lt;/p&gt;&lt;p&gt;Created by Mikael Hvidtfeldt Christensen.&lt;br /&gt;Licensed and distributed under the LPGL or GPL license.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Notice&lt;/b&gt;: some fragment (GLSL) shaders are copyright by other authors, and may carry other licenses. Please check the fragment file header before redistributing.&lt;h1&gt;Acknowledgement&lt;/h1&gt;&lt;p&gt;Much of the inspiration and formulas for Fragmentarium came from the community at &lt;a href=http://www.fractalforums.com&gt;FractalForums.com&lt;/a&gt;, including Tom Beddard, Jan Kadlec, IÃ±igo Quilez, Buddhi, Jesse, and others. Special thanks goes out to Knighty and Kali for their great fragments. All fragments should include information about their origins - please notify me, if I made any mis-attributions.&lt;/p&gt;&lt;p&gt;The icons used are part of the &lt;a href=&quot;http://www.everaldo.com/crystal/&quot;&gt;Everaldo: Crystal&lt;/a&gt; project. &lt;/p&gt;&lt;p&gt;Fragmentarium is built using the &lt;a href=&quot;http://trolltech.com/developer/downloads/qt/index&quot;&gt;Qt cross-platform GUI framework&lt;/a&gt;. &lt;/p&gt;&lt;/p&gt;&lt;p&gt;&lt;table cellspacing=20&gt;&lt;th colspan=2 align=left&gt;Translations by Fractal Forums users&lt;/th&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;SCORPION&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;Crist-JRoger&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;German&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Dutch&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/p&gt;</oldsource>
-        <translation>&lt;p&gt;Интегрированная среда для изучения пиксельной графики на базе GPU. &lt;/p&gt;
+        <translation type="vanished">&lt;p&gt;Интегрированная среда для изучения пиксельной графики на базе GPU. &lt;/p&gt;
 &lt;p&gt;ПО создано Михаэлем Хвидфилтом Кристенсеном (Mikael Hvidtfeldt Christensen).&lt;br /&gt;Лицензия зарегистрирована и распространяется по лицензии GPL или LGPL.&lt;/p&gt;
 &lt;p&gt;&lt;b&gt;Обратите внимание&lt;/b&gt;: некоторые фрагмент (GLSL) шейдеры являются собственностью других авторов, а также могут иметь другие лицензии. Пожалуйста, проверьте заголовок файла фрагмента перед распространением.
 &lt;h1&gt;Подтверждение&lt;/h1&gt;
@@ -689,7 +688,7 @@ and save to file before closing.
 &lt;/p&gt;</translation>
     </message>
     <message>
-        <location line="+19"/>
+        <location line="+22"/>
         <source>About Fragmentarium</source>
         <translation>О Фрагментариум</translation>
     </message>
@@ -771,7 +770,7 @@ and save to file before closing.
         <translation>Журнал событий</translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+19"/>
         <source>Variable Editor (uniforms)</source>
         <translation>Редактор переменных (uniforms)</translation>
     </message>
@@ -812,7 +811,14 @@ This option may be re-enabled through Preferences</source>
         <translation>Сначала создайте фрагмент!</translation>
     </message>
     <message>
-        <location line="+1019"/>
+        <location line="+108"/>
+        <source>Could not remove dependency:
+&apos;%1&apos;</source>
+        <translation>Не удалось удалить зависимость:
+&apos;%1&apos;</translation>
+    </message>
+    <message>
+        <location line="+931"/>
         <source>Reloaded file: %1</source>
         <translation>Перезагрузка файла: %1</translation>
     </message>
@@ -854,7 +860,7 @@ This option may be re-enabled through Preferences</source>
         <translation>Доступные форматы изображений: </translation>
     </message>
     <message>
-        <location line="+231"/>
+        <location line="+228"/>
         <source>// Cannot read file %1:
 // %2
 </source>
@@ -878,7 +884,7 @@ Close this tab without saving changes?</source>
         <translation>Не удалось разрешить OpenGL функции, необходимые для включения AsmBrowser</translation>
     </message>
     <message>
-        <location line="-2319"/>
+        <location line="-2336"/>
         <source>This is your first run of Fragmentarium.
 Please read this:
 
@@ -946,12 +952,12 @@ Please read this:
     </message>
     <message>
         <location line="+8"/>
-        <location line="+2626"/>
+        <location line="+2644"/>
         <source>&amp;Save</source>
         <translation>&amp;Сохранить</translation>
     </message>
     <message>
-        <location line="-2625"/>
+        <location line="-2643"/>
         <source>Ctrl+S</source>
         <translation></translation>
     </message>
@@ -1104,7 +1110,7 @@ Continue and loose changes?</source>
 Продолжить и потерять изменения?</translation>
     </message>
     <message>
-        <location line="+306"/>
+        <location line="+304"/>
         <source>&lt;p&gt;Notice: the 3D view must have keyboard focus!&lt;/p&gt;&lt;h2&gt;2D&lt;/h2&gt;&lt;p&gt;&lt;ul&gt;&lt;li&gt;Left mousebutton: translate center.&lt;/li&gt;&lt;li&gt;Right mousebutton: zoom.&lt;/li&gt;&lt;li&gt;Wheel: zoom&lt;/li&gt;&lt;li&gt;A/D: left/right&lt;/li&gt;&lt;li&gt;W/S: up/down&lt;/li&gt;&lt;li&gt;Q/E: zoom in/out&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;h2&gt;3D&lt;/h2&gt;&lt;p&gt;&lt;ul&gt;&lt;li&gt;Shift+Right mouse button: shows menus when in fullscreen mode.&lt;/li&gt;&lt;li&gt;Left mouse button: change camera direction.&lt;/li&gt;&lt;li&gt;Right mouse button: move camera in screen plane.&lt;/li&gt;&lt;li&gt;Left+Right mouse button: zoom.&lt;/li&gt;&lt;li&gt;Shift+Left mouse button: rotate object (around origin).&lt;/li&gt;&lt;li&gt;Shift+Alt+Left mouse button: rotate object (around target).&lt;/li&gt;&lt;li&gt;Shift+Tilde (~) resets the view to look through origin (0,0,0)&lt;/li&gt;&lt;li&gt;Wheel: Move forward/backward&lt;/li&gt;&lt;li&gt;W/S: move forward/back.&lt;/li&gt;&lt;li&gt;A/D: move left/right.&lt;/li&gt;&lt;li&gt;Q/E: roll&lt;/li&gt;&lt;li&gt;1/3: increase/decrease step size x2&lt;/li&gt;&lt;li&gt;2: increase/decrease step size x10&lt;/li&gt;&lt;li&gt;Shift+Wheel: change step size&lt;/li&gt;&lt;li&gt;T/G: move up/down.&lt;/li&gt;&lt;li&gt;R/F: yaw&lt;/li&gt;&lt;li&gt;Y/H: pitch&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;h2&gt;Sliders&lt;/h2&gt;&lt;p&gt;When a (float) slider recieves a Right Mouse Button Click it opens an input dialog to set the step size.&lt;br&gt;&lt;b&gt;F7 Key&lt;/b&gt; opens the easing curve editor for the currently selected slider.&lt;/p&gt;</source>
         <translation>&lt;p&gt;
   Обратите внимание: 3D вид должен иметь фокус клавиатуры!
@@ -1188,7 +1194,7 @@ Continue and loose changes?</source>
     &quot;&lt;/p&gt;&quot;</translation>
     </message>
     <message>
-        <location line="+234"/>
+        <location line="+236"/>
         <source>EXR &amp;Tools</source>
         <translation>EXR &amp;Инструменты</translation>
     </message>
@@ -1493,15 +1499,15 @@ Continue and loose changes?</source>
         <translation>// Создан: </translation>
     </message>
     <message>
-        <location line="+26"/>
+        <location line="+31"/>
         <source>Could not create directory %1:
 .</source>
         <translation>Невозможно создать каталог %1:
 .</translation>
     </message>
     <message>
-        <location line="+8"/>
-        <location line="+436"/>
+        <location line="+10"/>
+        <location line="+449"/>
         <location line="+606"/>
         <source>Cannot write file %1:
 %2.</source>
@@ -1510,7 +1516,7 @@ Continue and loose changes?</source>
 %2.</translation>
     </message>
     <message>
-        <location line="-1026"/>
+        <location line="-1033"/>
         <source>Could not copy dependency:
 &apos;%1&apos; to 
 &apos;%2&apos;.</source>
@@ -1522,9 +1528,10 @@ Continue and loose changes?</source>
 &apos;%2&apos;.</translation>
     </message>
     <message>
-        <location line="+439"/>
+        <location line="+446"/>
         <location line="+473"/>
-        <location line="+1257"/>
+        <location line="+1255"/>
+        <location line="+199"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Невозможно прочитать файл %1:
@@ -1549,38 +1556,66 @@ and save before closing!</source>
 и сохраните перед закрытием!</translation>
     </message>
     <message>
-        <location line="-22"/>
+        <location line="-221"/>
         <source>Cannot write CmdScript %1:
 %2.</source>
         <translation>Невозможно записать файл%1:
 %2.</translation>
     </message>
     <message>
-        <location line="-2171"/>
-        <location line="+8"/>
-        <location line="+16"/>
-        <location line="+420"/>
+        <location line="-2184"/>
+        <location line="+10"/>
+        <location line="+17"/>
+        <location line="+5"/>
+        <location line="+427"/>
         <location line="+19"/>
         <location line="+514"/>
         <location line="+72"/>
-        <location line="+1121"/>
+        <location line="+1119"/>
         <location line="+22"/>
         <source>Fragmentarium</source>
         <translation>Фрагментариум</translation>
     </message>
     <message>
-        <location line="-3329"/>
-        <location line="+2683"/>
+        <location line="-3347"/>
+        <location line="+2700"/>
         <source>Continue</source>
         <translation>Продолжать</translation>
     </message>
     <message>
-        <location line="-1532"/>
+        <location line="-2499"/>
+        <source>&lt;p&gt;An integrated environment for exploring GPU pixel graphics. &lt;/p&gt;&lt;p&gt;Created by Mikael Hvidtfeldt Christensen.&lt;br /&gt;Licensed and distributed under the LPGL or GPL license.&lt;/p&gt;&lt;p&gt;&lt;b&gt;Notice&lt;/b&gt;: some fragment (GLSL) shaders are copyright by other authors, and may carry other licenses. Please check the fragment file header before redistributing.&lt;h1&gt;Acknowledgement&lt;/h1&gt;&lt;p&gt;Much of the inspiration and formulas for Fragmentarium came from the community at &lt;a href=http://www.fractalforums.com&gt;FractalForums.com&lt;/a&gt;, including Tom Beddard, Jan Kadlec, Iñigo Quilez, Buddhi, Jesse, and others. Special thanks goes out to Knighty and Kali for their great fragments and claude for all his help with improvements. All fragments should include information about their origins - please notify me, if I made any mis-attributions.&lt;/p&gt;&lt;p&gt;The icons used are part of the &lt;a href=&quot;http://www.everaldo.com/crystal/&quot;&gt;Everaldo: Crystal&lt;/a&gt; project. &lt;/p&gt;&lt;p&gt;Fragmentarium is built using the &lt;a href=&quot;http://trolltech.com/developer/downloads/qt/index&quot;&gt;Qt cross-platform GUI framework&lt;/a&gt;. &lt;/p&gt;&lt;/p&gt;&lt;p&gt;&lt;table cellspacing=20&gt;&lt;th colspan=2 align=left&gt;Translations by Fractal Forums users&lt;/th&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;SCORPION&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Russian&lt;/td&gt;&lt;td align=center&gt;Crist-JRoger&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;German&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;Dutch&lt;/td&gt;&lt;td align=center&gt;Sabine&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Интегрированная среда для изучения пиксельной графики на базе GPU. &lt;/p&gt;
+&lt;p&gt;ПО создано Михаэлем Хвидфилтом Кристенсеном (Mikael Hvidtfeldt Christensen).&lt;br /&gt;Лицензия зарегистрирована и распространяется по лицензии GPL или LGPL.&lt;/p&gt;
+&lt;p&gt;&lt;b&gt;Обратите внимание&lt;/b&gt;: некоторые фрагмент (GLSL) шейдеры являются собственностью других авторов, а также могут иметь другие лицензии. Пожалуйста, проверьте заголовок файла фрагмента перед распространением.
+&lt;h1&gt;Подтверждение&lt;/h1&gt;
+&lt;p&gt;
+Большая часть вдохновения и формул для Фрагментариум пришли из сообщества в &lt;a href=&quot;http://www.fractalforums.com&quot;&gt; Фрактальные Форумы &lt;/a&gt;, в том числе Tom Beddard, Jan Kadlec, Iñigo Quilez, Buddhi, Jesse, и другие. Особая благодарность выходит Knighty и Каli для их больших фрагментов и Клод за всю его помощь с улучшениями. Все фрагменты должны включать информацию об их происхождении - пожалуйста, сообщите мне, если я сделал какие-либо MIS-атрибуции.
+&lt;/p&gt;
+&lt;p&gt;Значки, используемые являются частью &lt;a href=&quot;http://www.everaldo.com/crystal/&quot;&gt; Everaldo: Crystal &lt;/a&gt; проекта. &lt;/p&gt;
+&lt;p&gt;Фрагментариум построена с использованием &lt;a href=&quot;http://trolltech.com/developer/downloads/qt/index&quot;&gt; Qt кросс-платформенных GUI рамочное &lt;/a&gt;. &lt;/p&gt;
+
+&lt;/p&gt;
+&lt;p&gt;
+&lt;table cellspacing=&quot;20&quot;&gt;&lt;th colspan=2 align=&quot;left&quot;&gt;Переводы Fractal Forums пользователей&lt;/th&gt;
+&lt;tr&gt;&lt;td&gt;русский&lt;/td&gt;&lt;td align=&quot;center&quot;&gt;SCORPION&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;русский&lt;/td&gt;&lt;td align=&quot;center&quot;&gt;Crist-JRoger&lt;/td&gt;&lt;/tr&gt;
+&lt;tr&gt;&lt;td&gt;Немецкий&lt;/td&gt;&lt;td align=&quot;center&quot;&gt;sabine62&lt;/td&gt;&lt;/tr&gt;
+&lt;/table&gt;
+&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location line="+925"/>
+        <source>Do you want to use it? &lt;br&gt;&lt;br&gt;This will overwrite any existing files!</source>
+        <translation>Вы хотите использовать это? &lt;br&gt;&lt;br&gt; Это перезапишет любые существующие файлы!</translation>
+    </message>
+    <message>
+        <location line="+32"/>
         <source>Saved fragment + settings as: </source>
         <translation>Сохраненный фрагмент + настройки как: </translation>
     </message>
     <message>
-        <location line="+42"/>
+        <location line="+49"/>
         <source>is too large!
 Must be less than 32769x32769</source>
         <translation>слишком большой!
@@ -1602,7 +1637,7 @@ Must be less than 32769x32769</source>
         <translation>Прекратить</translation>
     </message>
     <message>
-        <location line="+276"/>
+        <location line="+282"/>
         <location line="+41"/>
         <source>Saved file : </source>
         <translation>Сохранённый файл : </translation>
@@ -1839,7 +1874,7 @@ Would you like to reload it?</source>
         <translation>Ваш код не запускается.</translation>
     </message>
     <message>
-        <location line="+58"/>
+        <location line="+55"/>
         <source>Compiled script in %1 ms.</source>
         <translation>Компилировать скрипт в %1 мс.</translation>
     </message>
@@ -1865,11 +1900,12 @@ Would you like to reload it?</source>
     </message>
     <message>
         <location line="+42"/>
+        <location line="+971"/>
         <source>Loaded file: %1</source>
         <translation>Загруженный файл:%1</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <location line="-963"/>
         <source>Unnamed</source>
         <translation>Без имени</translation>
     </message>
@@ -1884,12 +1920,30 @@ Would you like to reload it?</source>
         <translation>Если в пресете переменные заблокированы &quot;Сборка&quot; нажать ещё раз.</translation>
     </message>
     <message>
+        <source>Cannot read file %1:
+%2
+</source>
+        <translation type="obsolete">Невозможно прочитать файл %1:
+%2. {1:?} {2
+?}</translation>
+    </message>
+    <message>
+        <location line="+920"/>
+        <source>CMD Script (*.fqs);;All Files (*.*)</source>
+        <translation>Команда скрипта (*.fqs);;Все файлы (*.*)</translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>Bind CMD script to F6 key</source>
+        <translation>Привязать командный скрипт к клавише F6</translation>
+    </message>
+    <message>
         <source>OK</source>
         <translation type="vanished">Закрыть</translation>
     </message>
     <message>
-        <location line="-2647"/>
-        <location line="+2683"/>
+        <location line="-3586"/>
+        <location line="+2700"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
@@ -1969,7 +2023,7 @@ Would you like to reload it?</source>
         <translation>Должен быть .frag или .fragparams файл.</translation>
     </message>
     <message>
-        <location line="+338"/>
+        <location line="+339"/>
         <source>#endpreset not found!</source>
         <translation>#endpreset не найден!</translation>
     </message>
@@ -2011,6 +2065,7 @@ Would you like to reload it?</source>
     </message>
     <message>
         <location line="+65"/>
+        <location line="+113"/>
         <source>Error %1 at line %2</source>
         <translation>Ошибка %1 в строке %2</translation>
     </message>
@@ -2084,7 +2139,7 @@ Would you like to reload it?</source>
 <context>
     <name>Fragmentarium::GUI::SamplerWidget</name>
     <message>
-        <location filename="../Fragmentarium/GUI/VariableWidget.cpp" line="+765"/>
+        <location filename="../Fragmentarium/GUI/VariableWidget.cpp" line="+781"/>
         <source>Select a Texture</source>
         <translation>Выбор текстуры</translation>
     </message>
@@ -2177,22 +2232,22 @@ Or create them with &quot;F7&quot; hotkey for the selected float slider.</source
         <translation> настройки в буфер обмена</translation>
     </message>
     <message>
-        <location line="+118"/>
+        <location line="+119"/>
         <source>%1 locked variables: %2</source>
         <translation>%1 Заблокированные переменные: %2</translation>
     </message>
     <message>
-        <location line="+132"/>
+        <location line="+141"/>
         <source>Unsupported parameter</source>
         <translation>Неподдерживаемый параметр</translation>
     </message>
     <message>
-        <location line="+144"/>
+        <location line="+166"/>
         <source>Expected a key value pair, found: </source>
         <translation>Ожидаемое значение пары ключа, найдено: </translation>
     </message>
     <message>
-        <location line="+21"/>
+        <location line="+23"/>
         <source>Could not find: </source>
         <translation>Не могу найти: </translation>
     </message>
@@ -2725,7 +2780,7 @@ Or create them with &quot;F7&quot; hotkey for the selected float slider.</source
 <context>
     <name>Preprocessor</name>
     <message>
-        <location filename="../Fragmentarium/Parser/Preprocessor.cpp" line="+156"/>
+        <location filename="../Fragmentarium/Parser/Preprocessor.cpp" line="+253"/>
         <source>Including file: </source>
         <translation>Включить файл: </translation>
     </message>
@@ -2735,7 +2790,7 @@ Or create them with &quot;F7&quot; hotkey for the selected float slider.</source
         <translation>Включить buffershader: </translation>
     </message>
     <message>
-        <location line="+374"/>
+        <location line="+380"/>
         <source>Parse: </source>
         <translation>Разбираем: </translation>
     </message>
@@ -2743,7 +2798,7 @@ Or create them with &quot;F7&quot; hotkey for the selected float slider.</source
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../Fragmentarium/GUI/MainWindow.cpp" line="-978"/>
+        <location filename="../Fragmentarium/GUI/MainWindow.cpp" line="-1092"/>
         <source>Could not locate directory in: </source>
         <translation>Не удалось найти директорию в: </translation>
     </message>
@@ -2756,7 +2811,12 @@ Or create them with &quot;F7&quot; hotkey for the selected float slider.</source
 <context>
     <name>SyntopiaCore::Logging::ListWidget</name>
     <message>
-        <location filename="../SyntopiaCore/Logging/ListWidgetLogger.h" line="+28"/>
+        <location filename="../SyntopiaCore/Logging/ListWidgetLogger.h" line="+31"/>
+        <source>Open file</source>
+        <translation>Открыть файл</translation>
+    </message>
+    <message>
+        <location line="+1"/>
         <source>Copy to Clipboard</source>
         <translation>Скопировать в буфер обмена</translation>
     </message>
@@ -2766,7 +2826,7 @@ Or create them with &quot;F7&quot; hotkey for the selected float slider.</source
         <translation>Очистить</translation>
     </message>
     <message>
-        <location line="+11"/>
+        <location line="+32"/>
         <source>Copied %1 lines to clipboard</source>
         <translation>Скопировано %1 строк в буфер</translation>
     </message>


### PR DESCRIPTION
* This commit addresses Auto saving fragments and images.

Selecting No Auto Save and No Animation in the Render->High Resolution and Animation Render Dialog
will save a single image at the chosen location.
Selecting Auto Save will create a subfolder and save fragment files there.
Selecting Animation will save images in the subfolder/Images folder.
You can also re-use folders and overwrite their contents or continue a previously halted animation.

Passes tests with the Examples/Tutorials/30 - Simple Keyframe Animation.frag

* This commit updates German Dutch and Russian translation files