### PR TITLE
Feature exr loader flexible channel mapping

### DIFF
--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -729,7 +729,6 @@ bool DisplayWidget::loadEXRTexture(QString texturePath, GLenum type, GLuint text
         int h = dw.max.y - dw.min.y + 1;
         int s;
         context()->functions()->glGetIntegerv ( GL_MAX_TEXTURE_SIZE, &s );
-        s /= 4;
         if ( w>s || h>(s*6) ) {
             WARNING(tr("Exrloader found EXR image: %1 x %2 is too large! max %3x%3").arg(w).arg(h).arg(s));
             return false;

--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.h
@@ -212,7 +212,7 @@ public:
 
     bool buttonDown;
 
-    void clearTextureCache ( QMap<QString, bool>* textureCacheUsed );
+    void clearTextureCache ( QMap<QPair<QString, QStringList>, bool>* textureCacheUsed );
 
     QStringList getCurveSettings();
     void setCurveSettings ( const QStringList cset );
@@ -355,7 +355,7 @@ private:
 
     bool loadHDRTexture(QString texturePath, GLenum type, GLuint textureID, QString uniformName="");
 // #ifdef USE_OPEN_EXR
-    bool loadEXRTexture(QString texturePath, GLenum type, GLuint textureID, QString uniformName="");
+    bool loadEXRTexture(QString texturePath, GLenum type, GLuint textureID, QString uniformName="", QStringList channels=QStringList());
 // #endif
     bool loadQtTexture(QString texturePath, GLenum type, GLuint textureID, QString uniformName="");
 
@@ -394,7 +394,7 @@ private:
     GLenum bufferType;
 
     QDateTime tileRenderStart;
-    QMap<QString, int> TextureCache;
+    QMap<QPair<QString, QStringList>, int> TextureCache;
 
     bool doClearBackBuffer;
     QTimer* timer;

--- a/Fragmentarium-Source/Fragmentarium/GUI/VariableWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/VariableWidget.cpp
@@ -740,7 +740,10 @@ SamplerWidget::SamplerWidget(FileManager *fileManager, QWidget *parent, QWidget 
     {
         channelComboBox[channel] = new QComboBox(parent);
         channelComboBox[channel]->setEditable(false);
-        channelComboBox[channel]->setCurrentText(defaultChannelValue.at(channel));
+        if (defaultChannelValue.size() > channel)
+        {
+            channelComboBox[channel]->setCurrentText(defaultChannelValue.at(channel));
+        }
         channelComboBox[channel]->setObjectName(name+"Channel"+QString(channel));
 
         l->addWidget(channelComboBox[channel]);
@@ -748,7 +751,7 @@ SamplerWidget::SamplerWidget(FileManager *fileManager, QWidget *parent, QWidget 
         channelComboBox[channel]->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Maximum));
         channelComboBox[channel]->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn); // necessarily!
         channelComboBox[channel]->view()->setCornerWidget(new QSizeGrip(channelComboBox[channel]));
-        if(defaultChannelValue.at(channel).isEmpty()){
+        if(defaultChannelValue.size() <= channel || defaultChannelValue.at(channel).isEmpty()){
             channelComboBox[channel]->hide();
         }
         connect(channelComboBox[channel], SIGNAL(editTextChanged(const QString &)), this, SLOT(channelChanged(const QString &)));

--- a/Fragmentarium-Source/Fragmentarium/GUI/VariableWidget.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/VariableWidget.h
@@ -481,7 +481,7 @@ class SamplerWidget : public VariableWidget
     Q_OBJECT
 public:
     SamplerWidget ( FileManager *fileManager, QWidget *parent,
-                    QWidget *variableEditor, QString name, QString defaultValue, QString defaultChannelValue="" );
+                    QWidget *variableEditor, QString name, QString defaultValue, QStringList defaultChannelValue = QString("R G B A").split(" ") );
     virtual QString toString();
     virtual bool fromString(QString string);
     virtual void setUserUniform ( QOpenGLShaderProgram* shaderProgram );
@@ -492,6 +492,7 @@ public:
     } // cannot change this
     
     QString getValue() ;
+    QStringList getChannels();
     virtual QString getUniqueName()
     {
         return QString ( "%1:%2:%3:%4" ).arg ( group ).arg ( getName() );
@@ -499,22 +500,25 @@ public:
     void reset()
     {
         comboBox->setEditText ( defaultValue );
-        if(!defaultChannelValue.isEmpty()) {
-            channelComboBox->show();
-            int i = channelComboBox->findText(defaultChannelValue);
+        for (int channel = 0; channel < 4; ++channel)
+        {
+          if(!defaultChannelValue[channel].isEmpty()) {
+            channelComboBox[channel]->show();
+            int i = channelComboBox[channel]->findText(defaultChannelValue[channel]);
             if(i != -1) {
-                channelComboBox->setCurrentIndex(i);
+                channelComboBox[channel]->setCurrentIndex(i);
             }
-        } else channelComboBox->hide();
+          } else channelComboBox[channel]->hide();
+        }
     }
-    QString getChannelValue()
+    QString getChannelValue(int channel)
     {
-        if(!channelComboBox->isHidden())
-        return channelComboBox->currentText();
+        if(!channelComboBox[channel]->isHidden())
+        return channelComboBox[channel]->currentText();
         else return "";
     }
     
-    int hasChannel(QString chan);
+    int hasChannel(int channel, QString chan);
     
     QString getLockedSubstitution()
     {
@@ -544,11 +548,11 @@ protected slots:
 private:
 
     QComboBox* comboBox;
-    QComboBox* channelComboBox;
+    QComboBox* channelComboBox[4];
     QPushButton* pushButton;
     FileManager* fileManager;
     QString defaultValue;
-    QString defaultChannelValue;
+    QStringList defaultChannelValue;
 };
 
 class iSamplerWidget : public SamplerWidget
@@ -556,7 +560,7 @@ class iSamplerWidget : public SamplerWidget
     Q_OBJECT
 public:
     iSamplerWidget ( FileManager *fileManager, QWidget *parent,
-                    QWidget *variableEditor, QString name, QString defaultValue, QString defaultChannelValue="" );
+                    QWidget *variableEditor, QString name, QString defaultValue, QStringList defaultChannelValue = QString("R G B A").split(" ") );
 
 signals:
 
@@ -571,7 +575,7 @@ class uSamplerWidget : public SamplerWidget
     Q_OBJECT
 public:
     uSamplerWidget ( FileManager *fileManager, QWidget *parent,
-                    QWidget *variableEditor, QString name, QString defaultValue, QString defaultChannelValue="" );
+                    QWidget *variableEditor, QString name, QString defaultValue, QStringList defaultChannelValue = QString("R G B A").split(" ") );
 
 signals:
 

--- a/Fragmentarium-Source/Fragmentarium/Parser/Preprocessor.cpp
+++ b/Fragmentarium-Source/Fragmentarium/Parser/Preprocessor.cpp
@@ -438,7 +438,7 @@ void Preprocessor::parseSampler2D(FragmentSource *fs, int i, QString file)
     if (QFileInfo(fileName).isFile()) {
         INFO("Added texture: " + name + " -> " + fileName);
     }
-    fs->textures[name] = fileName;
+    fs->textures[name] = QPair<QString,QStringList>(fileName, QStringList());
     SamplerParameter *sp = new SamplerParameter(currentGroup, name, lastComment, fileName);
     setLockType(sp, "alwayslocked");
     fs->params.append(sp);
@@ -449,7 +449,7 @@ void Preprocessor::parseSampler2DChannel(FragmentSource *fs, int i, QString file
     QString name = sampler2DChannel.cap(1);
     fs->source[i] = "uniform sampler2D " + name + ";";
     QString fileName;
-    QString channelName = sampler2DChannel.cap(3);
+    QStringList channelNames = sampler2DChannel.cap(3).split(" ");
     
     try {
         fileName = fileManager->resolveName(sampler2DChannel.cap(2), file);
@@ -457,10 +457,10 @@ void Preprocessor::parseSampler2DChannel(FragmentSource *fs, int i, QString file
         CRITICAL(e.getMessage());
     }
     if (QFileInfo(fileName).isFile()) {
-        INFO("Added texture: " + name + " -> " + fileName + " using channel:" + channelName);
+        INFO("Added texture: " + name + " -> " + fileName + " using channels:" + channelNames.join(" "));
     }
-    fs->textures[name] = fileName;
-    SamplerParameter *sp = new SamplerParameter(currentGroup, name, lastComment, fileName, channelName);
+    fs->textures[name] = QPair<QString,QStringList>(fileName, channelNames);
+    SamplerParameter *sp = new SamplerParameter(currentGroup, name, lastComment, fileName, channelNames);
     setLockType(sp, "alwayslocked");
     fs->params.append(sp);
 }
@@ -478,7 +478,7 @@ void Preprocessor::parseSamplerCube(FragmentSource *fs, int i, QString file)
     if (QFileInfo(fileName).isFile()) {
         INFO("Added Cube texture: " + name + " -> " + fileName);
     }
-    fs->textures[name] = fileName;
+    fs->textures[name] = QPair<QString,QStringList>(fileName, QStringList());
     SamplerParameter *sp = new SamplerParameter(currentGroup, name, lastComment, fileName);
     setLockType(sp, "alwayslocked");
     fs->params.append(sp);

--- a/Fragmentarium-Source/Fragmentarium/Parser/Preprocessor.h
+++ b/Fragmentarium-Source/Fragmentarium/Parser/Preprocessor.h
@@ -180,7 +180,7 @@ protected:
 
 class SamplerParameter : public GuiParameter {
 public:
-    SamplerParameter(QString group, QString name,QString tooltip, QString defaultValue, QString defaultChannel="") :
+    SamplerParameter(QString group, QString name,QString tooltip, QString defaultValue, QStringList defaultChannel=QStringList()) :
         GuiParameter(group, name, tooltip), defaultValue(defaultValue), defaultChannel(defaultChannel) {}
 
     virtual QString getUniqueName() {
@@ -189,12 +189,12 @@ public:
     QString getDefaultValue() {
         return defaultValue;
     }
-    QString getDefaultChannelValue() {
+    QStringList getDefaultChannelValue() {
         return defaultChannel;
     }
 private:
     QString defaultValue;
-    QString defaultChannel;
+    QStringList defaultChannel;
 };
 
 class FloatParameter : public GuiParameter {
@@ -395,7 +395,7 @@ public:
     QString camera;
     QString buffer;
     QVector<GuiParameter*> params;
-    QMap<QString, QString> textures; // "Uniform name" -> "File"
+    QMap<QString, QPair<QString, QStringList>> textures; // "Uniform name" -> ("File", "Channels")
     QMap<QString, QString> presets;
     QMap<QString, QMap<QString, QString> > textureParams; // foreach texturename, store parameters
 
@@ -426,11 +426,11 @@ public:
     static QRegExp replace ( "^#replace\\s+\"([^\"]+)\"\\s+\"([^\"]+)\"\\s*$" ); // Look for #replace "var1" "var2"
     
     static QRegExp sampler2D (        "^\\s*uniform\\s+sampler2D\\s+(\\S+);\\s*file\\[(\\S+)\\].*$" );
-    static QRegExp sampler2DChannel ( "^\\s*uniform\\s+sampler2D\\s+(\\S+);\\s*file\\[(\\S+),\\s+(\\S+)\\].*$" );
+    static QRegExp sampler2DChannel ( "^\\s*uniform\\s+sampler2D\\s+(\\S+);\\s*file\\[(\\S+),\\s+([^]]+)\\].*$" );
     static QRegExp isampler2D (        "^\\s*uniform\\s+isampler2D\\s+(\\S+);\\s*file\\[(\\S+)\\].*$" );
-    static QRegExp isampler2DChannel ( "^\\s*uniform\\s+isampler2D\\s+(\\S+);\\s*file\\[(\\S+),\\s+(\\S+)\\].*$" );
+    static QRegExp isampler2DChannel ( "^\\s*uniform\\s+isampler2D\\s+(\\S+);\\s*file\\[(\\S+),\\s+([^]]+)\\].*$" );
     static QRegExp usampler2D (        "^\\s*uniform\\s+usampler2D\\s+(\\S+);\\s*file\\[(\\S+)\\].*$" );
-    static QRegExp usampler2DChannel ( "^\\s*uniform\\s+usampler2D\\s+(\\S+);\\s*file\\[(\\S+),\\s+(\\S+)\\].*$" );
+    static QRegExp usampler2DChannel ( "^\\s*uniform\\s+usampler2D\\s+(\\S+);\\s*file\\[(\\S+),\\s+([^]]+)\\].*$" );
 
     static QRegExp samplerCube ( "^\\s*uniform\\s+samplerCube\\s+(\\S+)\\s*;\\s*file\\[(.*)\\].*$" );
     static QRegExp doneClear ( "^\\s*#define\\s+dontclearonchange$",Qt::CaseInsensitive );


### PR DESCRIPTION
- remove arbitrary(?) size factor preventing loading large EXR

- DisplayWidget::loadEXRTexture has a list of channels to load, defaulting
  to R G B A.  The file reading is refactored to read the whole image at once.
  Four slices are added, but note that if the same channel name is specified
  more than once, only the last takes effect (earlier slices will be 0).  The
  texture internal format is forced to GL_RGBA32F for high dynamic range
  (previously was GL_RGBA which might be one byte per channel).

- The TextureCache now stores a channel list as well as the filename.  For all
  types other than EXR, the list will be empty, but we need it for EXR in case
  the channel mapping changes which means we need to reload the texture.  This
  should also make it possible to load the same file more than once with other
  channel mappings, for files with more than 4 channels, but I have not tested
  this aspect yet.

- SamplerWidget has 4 channel mapping combo boxes which are populated from the
  available channels when an EXR file is selected.

  - The "exr" extension is
    added to the file selection dialog if any of Q_OS_WIN and USE_OPEN_EXR are
    defined (previously on Linux with USE_OPEN_EXR exr files were only visible
    when selecting to view all files, rather than images). 

  - A new getChannels()
    method returns the list of channels for EXR, an empty list otherwise.

  - SamplerWidget preset text is the filename followed by space-separated list
    of channels for EXR.  This probably breaks if there is a space in the file
    path.

- SamplerParameter regexps tweaked slightly, untested, not sure what the
  expected input/output is of this stuff.

- (i|u)samplers still not implemented, nor half, FLOAT is all you get for now.