### PR TITLE
an option to keep the time free-running on frag rebuild

### DIFF
--- a/Fragmentarium-Source/Examples/Experimental/AnimationModeTest.frag
+++ b/Fragmentarium-Source/Examples/Experimental/AnimationModeTest.frag
@@ -1,0 +1,33 @@
+#info Animation Playback Mode test example
+#info activate animation playback with 10 second duration
+#info toggle #if or make other changes and trigger rebuild
+#info observe behaviour of time playback cursor
+#info compare with animation playback mode checkbox in preferences toggled
+
+#include "MathUtils.frag"
+#include "DE-Raytracer.frag" 
+
+uniform float time;
+
+float t = 2.0 * 3.141592653 * time / 10.0;
+float c = cos(t);
+float s = sin(t);
+mat2 transform = mat2(c, s, -s, c);
+
+#if 1
+float ballSize = 1.2;
+#else
+float ballSize = 2.0;
+#endif
+
+float DE(vec3 pos) {
+	pos.xy *= transform;
+	return abs(length(abs(pos)+vec3(-1.0))-ballSize);
+}
+
+#preset Default
+FOV = 0.4
+Eye = 5.582327,4.881191,-6.709066
+Target = 0,0,0
+Up = -0.1207781,0.8478234,0.5163409
+#endpreset

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.cpp
@@ -2138,12 +2138,14 @@ void MainWindow::rewind()
     engine->update();
 }
 
-void MainWindow::play()
+void MainWindow::play( bool restart )
 {
 
     playAction->setEnabled(false);
     stopAction->setEnabled(true);
-    lastTime->restart();
+    if (restart) {
+        lastTime->restart();
+    }
     engine->setContinuous(true);
     getTime();
     pausePlay=false;
@@ -2675,7 +2677,7 @@ bool MainWindow::initializeFragment()
 
         INFO(tr("Compiled script in %1 ms.").arg(ms));
         engine->setState(oldState);
-        pause ? stop() : play();
+        pause ? stop() : play(! settings.value("animationMode", false).toBool());
 
         hideUnusedVariableWidgets();
 

--- a/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/MainWindow.h
@@ -490,7 +490,7 @@ public slots:
     void documentWasModified();
     void closeTab ( int index );
     void rewind();
-    void play();
+    void play( bool restart = true );
     void stop();
     // for benchmark script
     int getTileAVG()

--- a/Fragmentarium-Source/Fragmentarium/GUI/PreferencesDialog.h
+++ b/Fragmentarium-Source/Fragmentarium/GUI/PreferencesDialog.h
@@ -112,6 +112,7 @@ private slots:
         m_ui.jtloeCheckBox->setChecked (settings.value ( "jumpToLineOnError", true ).toBool() );
         m_ui.jtlowCheckBox->setChecked (settings.value ( "jumpToLineOnWarn", false ).toBool() );
         m_ui.ddCameraModeCheckBox->setChecked (settings.value ( "ddCameraMode", false ).toBool() );
+        m_ui.animationModeCheckBox->setChecked (settings.value ( "animationMode", false ).toBool() );
         m_ui.enableGLDebugCheckBox->setChecked (settings.value ( "enableGLDebug", false ).toBool() );
 #ifdef USE_OPEN_EXR
         m_ui.exrBinPathsLineEdit->setText (settings.value ( "exrBinPaths", "./bin;/usr/bin;" ).toString() );
@@ -143,6 +144,7 @@ private slots:
         settings.setValue ( "jumpToLineOnError", m_ui.jtloeCheckBox->isChecked() );
         settings.setValue ( "jumpToLineOnWarn", m_ui.jtlowCheckBox->isChecked() );
         settings.setValue ( "ddCameraMode", m_ui.ddCameraModeCheckBox->isChecked() );
+        settings.setValue ( "animationMode", m_ui.animationModeCheckBox->isChecked() );
         settings.setValue ( "enableGLDebug", m_ui.enableGLDebugCheckBox->isChecked() );
 #ifdef USE_OPEN_EXR
         settings.setValue("exrBinPaths", m_ui.exrBinPathsLineEdit->text());

--- a/Fragmentarium-Source/Fragmentarium/GUI/PreferencesDialog.ui
+++ b/Fragmentarium-Source/Fragmentarium/GUI/PreferencesDialog.ui
@@ -407,6 +407,16 @@
         </property>
        </widget>
       </item>
+      <item row="8" column="1">
+       <widget class="QCheckBox" name="animationModeCheckBox">
+        <property name="text">
+         <string>Animation update on=continuous off=last set</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
- preferences checkbox option to set animation update mode
- unchecked by default, as before
- play() takes a flag to inhibit resetting the playback timer
  (default: timer restarts, as before)
- makes this initializeFragment() logic smooth during animation:
  `stop(); ... if (wasPlaying) play(restart)`
  by passing along the preferences flag to the restart flag
- simple frag with instructions on how to test the feature
- verified that manual stop/start works as expected in both
  animation update modes

Fixes: <https://github.com/3Dickulus/FragM/issues/113>