### PR TITLE
fix crash due to wrong index in foundDouble branch

### DIFF
--- a/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
+++ b/Fragmentarium-Source/Fragmentarium/GUI/DisplayWidget.cpp
@@ -1500,7 +1500,11 @@ void DisplayWidget::setShaderUniforms(QOpenGLShaderProgram *shaderProg)
                 }
             }
         } else {
-            vw[i]->setIsDouble(foundDouble);
+            for( int n=0; n < vw.count(); n++) {
+                if(uniformName == vw[n]->getName()) {
+                    vw[n]->setIsDouble(foundDouble);
+                }
+            }
         } // this takes care of buffershader (Post) sliders :D
 
         // type name and value to console


### PR DESCRIPTION
`i` is relative to `GL_ACTIVE_UNIFORMS`, not `vw.size()`, so
we need to search the right `n` by comparing uniform names.