### PR TITLE
Add an explicit include for Imath

### DIFF
--- a/Fragmentarium-Source/Fragmentarium.pro
+++ b/Fragmentarium-Source/Fragmentarium.pro
@@ -69,7 +69,8 @@ PRE_TARGETDEPS += C:\Fragmentarium-2.5.6-3Dickulus-full\OpenEXR/lib/libIlmImf-2_
 }
 else:unix:CONFIG(release, debug|release) {
 INCLUDEPATH += /usr/include/OpenEXR \
-               /usr/include/glm
+               /usr/include/glm \
+               /usr/include/Imath
 }
 
 INCLUDEPATH += . \


### PR DESCRIPTION
In recent versions of OpenEXR, it seems that half.h has been moved to a separate package (imath) and separate include paths.